### PR TITLE
Add simple structure for the exposed API in window

### DIFF
--- a/src/cmp/application/ConsentManagementProvider.js
+++ b/src/cmp/application/ConsentManagementProvider.js
@@ -1,0 +1,1 @@
+export default class ConsentManagementProvider {}

--- a/src/cmp/infrastructure/Log.js
+++ b/src/cmp/infrastructure/Log.js
@@ -1,0 +1,18 @@
+export default class Log {
+  constructor({console}) {
+    this._console = console
+  }
+
+  debug(...args) {
+    this._print({level: 'DEBUG', args})
+  }
+
+  error(...args) {
+    this._print({level: 'ERROR', args})
+  }
+
+  _print({level, ...args}) {
+    const [message, ...rest] = [...args]
+    this._console.log(`[${level}] CMP - ${message}`, ...rest)
+  }
+}

--- a/src/cmp/infrastructure/commandConsumer.js
+++ b/src/cmp/infrastructure/commandConsumer.js
@@ -1,0 +1,15 @@
+const commandConsumer = log => cmp => (command, parameters, observer) => {
+  return Promise.resolve()
+    .then(() => log.debug('Received command:', command))
+    .then(() => {
+      if (command && typeof cmp[command] === 'function') {
+        return Promise.resolve(cmp[command](parameters))
+          .then(result => observer(...result))
+          .then(null)
+      } else {
+        return Promise.reject(new Error('Unexisting command: ' + command))
+      }
+    })
+    .catch(e => log.error('Error executing command:', command, '-', e.message))
+}
+export default commandConsumer

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,8 @@
+import commandConsumer from './cmp/infrastructure/commandConsumer'
+import ConsentManagementProvider from './cmp/application/ConsentManagementProvider'
+import Log from './cmp/infrastructure/Log'
+
+const log = new Log({console})
+const cmp = new ConsentManagementProvider()
+
+window.__cmp = window.__cmp || commandConsumer(log)(cmp)

--- a/test/cmp/infrastructure/commandConsumerTest.js
+++ b/test/cmp/infrastructure/commandConsumerTest.js
@@ -1,0 +1,46 @@
+/* eslint-disable prettier/prettier */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import commandConsumer from '../../../src/cmp/infrastructure/commandConsumer'
+
+describe('commandConsumer', () => {
+  const logMock = () => ({
+    debug: () => null,
+    error: () => null
+  })
+  const cmpMock = ({getConsentDataResult = () => null} = {}) => ({
+    getConsentData: () => Promise.resolve().then(() => getConsentDataResult())
+  })
+  describe('Given an executable command', () => {
+    it('Should call the valid CMP command and end with a callback  if command runs without errors', done => {
+      const resultData = [{key: 'value'}, true]
+      const log = logMock()
+      const cmp = cmpMock({getConsentDataResult: () => resultData})
+      const getConsentDataSpy = sinon.spy(cmp, 'getConsentData')
+      const parameters = {
+        key: 'value'
+      }
+      const callbackMock = sinon.spy()
+      commandConsumer(log)(cmp)('getConsentData', parameters, callbackMock)
+          .then(() => expect(getConsentDataSpy.calledOnce, 'CMP method shoud be called').to.be.true)
+          .then(() => expect(getConsentDataSpy.args[0][0], 'CMP call should recieve the parameters').to.deep.equals(parameters))
+          .then(() => expect([callbackMock.args[0][0], callbackMock.args[0][1]], 'CMP call should call the callback with object and success value').to.deep.equals([resultData[0], resultData[1]]))
+          .then(() => done())
+          .catch(e => done(e))
+    })
+  })
+    describe('Given an inexisting command', () => {
+        it('Should log an error', done => {
+            const log = logMock()
+            const cmp = cmpMock()
+            const parameters = 'whatever'
+            const observer = () => 'whatever'
+            const logErrorSpy = sinon.spy(log, 'error')
+            commandConsumer(log)(cmp)('whatever', parameters, observer)
+                .then(() => expect(logErrorSpy.calledOnce, 'Should have logged the error').to.be.true)
+                .then(() => expect(logErrorSpy.args[0].join(), 'The error should indicate that the command does not exist').to.include('Unexisting command'))
+                .then(() => done())
+                .catch(e => done(e))
+        })
+    })
+})


### PR DESCRIPTION
This PR includes:

* basic application-level structure to consume the client command calls and process them into promises
* ensure to call the callback on OK results

![](https://media.giphy.com/media/hfO80OKy85qgw/giphy.gif)