### PR TITLE
Add Infrastructure controller for the IAB CMP to develop

### DIFF
--- a/src/cmp/domain/InvalidVendorListVersionError.js
+++ b/src/cmp/domain/InvalidVendorListVersionError.js
@@ -1,0 +1,8 @@
+export default class InvalidVendorListVersionError extends Error {
+  constructor({vendorListVersion}) {
+    super()
+    this.name = 'InvalidVendorListVersionError'
+    this.message = `Vendor list version ${vendorListVersion} is not valid.`
+    this.stack = new Error().stack
+  }
+}

--- a/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
+++ b/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
@@ -1,0 +1,37 @@
+import InvalidVendorListVersionError from '../../domain/InvalidVendorListVersionError'
+
+export default class IABConsentManagementProviderV1 {
+  constructor({consentManagementProvider}) {
+    this._consentManagementProvider = consentManagementProvider
+  }
+
+  getVendorConsents(vendorIds, observer) {
+    return this._consentManagementProvider
+      .getVendorConsents({vendorIds})
+      .then(vendorConsents => observer(vendorConsents, true))
+  }
+
+  getConsentData(consentStringVersion, observer) {
+    return this._consentManagementProvider
+      .getConsentData({consentStringVersion})
+      .then(vendorConsentData => observer(vendorConsentData, true))
+  }
+
+  ping(_, observer) {
+    return this._consentManagementProvider
+      .ping()
+      .then(pingReturn => observer(pingReturn, true))
+  }
+
+  getVendorList(vendorListVersion, observer) {
+    return this._consentManagementProvider
+      .getVendorList({vendorListVersion})
+      .then(globalVendorList => observer(globalVendorList, true))
+      .catch(
+        e =>
+          e instanceof InvalidVendorListVersionError
+            ? observer(null, false)
+            : Promise.reject(e)
+      )
+  }
+}

--- a/src/cmp/infrastructure/controller/commandConsumer.js
+++ b/src/cmp/infrastructure/controller/commandConsumer.js
@@ -1,11 +1,15 @@
-const commandConsumer = log => cmp => (command, parameters, observer) => {
+const commandConsumer = log => controller => (
+  command,
+  parameters,
+  observer
+) => {
   return Promise.resolve()
     .then(() => log.debug('Received command:', command))
     .then(() => {
-      if (command && typeof cmp[command] === 'function') {
-        return Promise.resolve(cmp[command](parameters))
-          .then(result => observer(...result))
-          .then(null)
+      if (command && typeof controller[command] === 'function') {
+        return Promise.resolve(controller[command](parameters, observer)).then(
+          null
+        )
       } else {
         return Promise.reject(new Error('Unexisting command: ' + command))
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
-import commandConsumer from './cmp/infrastructure/commandConsumer'
-import ConsentManagementProvider from './cmp/application/ConsentManagementProvider'
 import Log from './cmp/infrastructure/Log'
+import ConsentManagementProvider from './cmp/application/ConsentManagementProvider'
+import IABConsentManagementProviderV1 from './cmp/infrastructure/controller/IABConsentManagementProviderV1'
+import commandConsumer from './cmp/infrastructure/controller/commandConsumer'
 
 const log = new Log({console})
 const cmp = new ConsentManagementProvider()
+const iabCMP = new IABConsentManagementProviderV1({
+  consentManagementProvider: cmp
+})
 
-window.__cmp = window.__cmp || commandConsumer(log)(cmp)
+window.__cmp = window.__cmp || commandConsumer(log)(iabCMP)

--- a/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
+++ b/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
@@ -1,0 +1,31 @@
+/* eslint-disable prettier/prettier */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import IABConsentManagementProviderV1 from "../../../../src/cmp/infrastructure/controller/IABConsentManagementProviderV1";
+
+describe('IAB Consent Management Provider V1', () => {
+    describe('getConsentData method', () => {
+        it('Should call the CMP provider to get the consent data and call the observer with success value', (done) => {
+            const givenConsentStringVersion = 'whatever'
+            const expectedResult = 'expected result'
+            const consentManagementProviderMock = {
+                getConsentData: () => Promise.resolve().then(() => expectedResult)
+            }
+            const getConsentDataSpy = sinon.spy(consentManagementProviderMock, 'getConsentData')
+            const observerSpy = sinon.spy()
+
+
+            const iabCMP = new IABConsentManagementProviderV1({consentManagementProvider: consentManagementProviderMock})
+            iabCMP.getConsentData(givenConsentStringVersion, observerSpy)
+                .then(() => {
+                    expect(getConsentDataSpy.calledOnce, 'CMP shoud have been called').to.be.true
+                    expect(getConsentDataSpy.args[0][0], 'CMP should have received only the business parameters').to.deep.equals({consentStringVersion: givenConsentStringVersion})
+                    expect(observerSpy.calledOnce, 'Observer should have been called').to.be.true
+                    expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
+                    expect(observerSpy.args[0][1]).to.be.true
+                })
+                .then(() => done())
+                .catch(e => done(e))
+        })
+    })
+})

--- a/test/cmp/infrastructure/controller/commandConsumerTest.js
+++ b/test/cmp/infrastructure/controller/commandConsumerTest.js
@@ -1,30 +1,31 @@
 /* eslint-disable prettier/prettier */
 import {expect} from 'chai'
 import sinon from 'sinon'
-import commandConsumer from '../../../src/cmp/infrastructure/commandConsumer'
+import commandConsumer from '../../../../src/cmp/infrastructure/controller/commandConsumer'
 
 describe('commandConsumer', () => {
   const logMock = () => ({
     debug: () => null,
     error: () => null
   })
-  const cmpMock = ({getConsentDataResult = () => null} = {}) => ({
+  const controllerMock = ({getConsentDataResult = () => null} = {}) => ({
     getConsentData: () => Promise.resolve().then(() => getConsentDataResult())
   })
   describe('Given an executable command', () => {
-    it('Should call the valid CMP command and end with a callback  if command runs without errors', done => {
-      const resultData = [{key: 'value'}, true]
+    it('Should call the valid CMP controller command without errors', done => {
       const log = logMock()
-      const cmp = cmpMock({getConsentDataResult: () => resultData})
-      const getConsentDataSpy = sinon.spy(cmp, 'getConsentData')
+      const controller = controllerMock()
+      const getConsentDataSpy = sinon.spy(controller, 'getConsentData')
       const parameters = {
         key: 'value'
       }
-      const callbackMock = sinon.spy()
-      commandConsumer(log)(cmp)('getConsentData', parameters, callbackMock)
+      const observer = () => null
+      const __cmp = commandConsumer(log)(controller)
+
+      __cmp('getConsentData', parameters, observer)
           .then(() => expect(getConsentDataSpy.calledOnce, 'CMP method shoud be called').to.be.true)
           .then(() => expect(getConsentDataSpy.args[0][0], 'CMP call should recieve the parameters').to.deep.equals(parameters))
-          .then(() => expect([callbackMock.args[0][0], callbackMock.args[0][1]], 'CMP call should call the callback with object and success value').to.deep.equals([resultData[0], resultData[1]]))
+          .then(() => expect(getConsentDataSpy.args[0][1], 'CMP call should recieve the callback').to.equals(observer))
           .then(() => done())
           .catch(e => done(e))
     })
@@ -32,11 +33,11 @@ describe('commandConsumer', () => {
     describe('Given an inexisting command', () => {
         it('Should log an error', done => {
             const log = logMock()
-            const cmp = cmpMock()
+            const controller = controllerMock()
             const parameters = 'whatever'
             const observer = () => 'whatever'
             const logErrorSpy = sinon.spy(log, 'error')
-            commandConsumer(log)(cmp)('whatever', parameters, observer)
+            commandConsumer(log)(controller)('whatever', parameters, observer)
                 .then(() => expect(logErrorSpy.calledOnce, 'Should have logged the error').to.be.true)
                 .then(() => expect(logErrorSpy.args[0].join(), 'The error should indicate that the command does not exist').to.include('Unexisting command'))
                 .then(() => done())


### PR DESCRIPTION
This PR includes changes for the command consumption, as infrastructure controller

* This allows the separation of business concerns from application layer down
* The infrastructure controller is the responsible of calling the callback and transforming the application results to IAB CMP 1.1 specific result in callback

![](https://media.giphy.com/media/l4EpblDY4msVtKAOk/giphy.gif)