### PR TITLE
Feature/get vendor list use case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,8 +6545,7 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -52,5 +52,7 @@
       "./node_modules/@s-ui/lint/eslintrc.js"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "whatwg-fetch": "^2.0.4"
+  }
 }

--- a/src/cmp/application/GetVendorListUseCase.js
+++ b/src/cmp/application/GetVendorListUseCase.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-undef */
+import 'whatwg-fetch'
+
+export default class GetVendorListUseCase {
+  constructor({vendorRepository}) {
+    this._vendorRepository = vendorRepository
+  }
+  /**
+   * The result will be the GlobalVendorList being the vendor list object of the requested version.
+   * If the vendorListVersion is null, the vendor list for the VendorListVersion in the current consent string is returned.
+   * If no consent string value is currently set, the latest version of the vendor list is returned.
+   * If the vendorListVersion value is ?LATEST?, the latest version available is returned.
+   * If the vendorListVersion is invalid, an InvalidVendorListError is thrown.
+   * @param vendorListVersion
+   */
+  getVendorList({vendorListVersion = null} = {}) {
+    return Promise.resolve().then(() =>
+      this._vendorRepository.getGlobalVendorList()
+    )
+  }
+}

--- a/src/cmp/domain/VendorRepository.js
+++ b/src/cmp/domain/VendorRepository.js
@@ -1,0 +1,8 @@
+/**
+ * @interface
+ */
+export default class VendorRepository {
+  getGlobalVendorList() {
+    throw new Error('VendorRepository#getGlobalVendorList must be implemented')
+  }
+}

--- a/src/cmp/infrastructure/repository/HttpVendorRepository.js
+++ b/src/cmp/infrastructure/repository/HttpVendorRepository.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-undef */
+import 'whatwg-fetch'
+
+/**
+ * @class
+ * @implements VendorRepository
+ */
+export default class HttpVendorRepository {
+  constructor({
+    globalVendorListLocation = 'https://vendorlist.consensu.org/vendorlist.json'
+  } = {}) {
+    this._globalVendorListLocation = globalVendorListLocation
+  }
+
+  getGlobalVendorList() {
+    return Promise.resolve()
+      .then(() => fetch(this._globalVendorListLocation))
+      .then(fetchResponse => fetchResponse.json())
+  }
+}

--- a/test/cmp/application/GetVendorListUseCaseTest.js
+++ b/test/cmp/application/GetVendorListUseCaseTest.js
@@ -1,0 +1,27 @@
+/* eslint-disable prettier/prettier */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import GetVendorListUseCase from "../../../src/cmp/application/GetVendorListUseCase";
+
+describe('Get Vendor List Use Case', () => {
+    it('Should return the global vendor list', done => {
+        const expectedResult = 'whatever result'
+        const vendorRepositoryMock = {
+            getGlobalVendorList: () => Promise.resolve(expectedResult)
+        }
+
+        const useCase = new GetVendorListUseCase({
+            vendorRepository: vendorRepositoryMock
+        })
+
+        const getGlobalVendorListSpy = sinon.spy(vendorRepositoryMock, 'getGlobalVendorList')
+
+        useCase.getVendorList()
+            .then(result => {
+                expect(getGlobalVendorListSpy.calledOnce, 'result should be the vendor list returned by the repository').to.be.true
+                expect(result, 'result should be the vendor list returned by the repository').to.deep.equal(expectedResult)
+            })
+            .then(() => done())
+            .catch(e => done(e))
+    })
+})

--- a/test/cmp/application/PingUseCaseTest.js
+++ b/test/cmp/application/PingUseCaseTest.js
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
 import {expect} from 'chai'
-import PingUseCase from "../../../src/cmp/application/PingUseCase";
+import PingUseCase from '../../../src/cmp/application/PingUseCase'
 
 describe('Ping Use Case', () => {
     it('Should return directly with the IAB PingReturn specification', done => {

--- a/test/cmp/infrastructure/repository/HttpVendorRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/HttpVendorRepositoryTest.js
@@ -1,0 +1,54 @@
+/* eslint-disable prettier/prettier */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import HttpVendorRepository from '../../../../src/cmp/infrastructure/repository/HttpVendorRepository'
+
+describe('HTTP Vendor Repository', () => {
+    describe('getGlobalVendorList', () => {
+        it('Should fetch the remote vendor list JSON, using the default location if none is given', done => {
+            const repository = new HttpVendorRepository()
+
+            const expectedResult = {
+                key: 'value'
+            }
+            const fetchMock = {
+                fetch: () => ({
+                    json: () => expectedResult
+                })
+            }
+            const fetchSpy = sinon.spy(fetchMock, 'fetch')
+            global.fetch = fetchMock.fetch
+
+
+            repository.getGlobalVendorList()
+                .then(result => {
+                    expect(fetchSpy.calledOnce, 'should have called the remote fetch method').to.be.true
+                    expect(fetchSpy.args[0][0], 'should retrieve the IAB vendor list by default').to.equal('https://vendorlist.consensu.org/vendorlist.json')
+                    expect(result, 'should return the fetched value as json output format').to.deep.equal(expectedResult)
+                })
+                .then(() => done())
+                .catch(e => done(e))
+        })
+        it('Should fetch the remote vendor list JSON, using the given vendor list location', done => {
+            const givenVendorListLocation = 'http://whatever.consent/location/list.json'
+            const repository = new HttpVendorRepository({globalVendorListLocation: givenVendorListLocation})
+
+            const fetchMock = {
+                fetch: () => ({
+                    json: () => null
+                })
+            }
+            const fetchSpy = sinon.spy(fetchMock, 'fetch')
+            global.fetch = fetchMock.fetch
+
+
+            repository.getGlobalVendorList()
+                .then(result => {
+                    expect(fetchSpy.calledOnce, 'should have called the remote fetch method').to.be.true
+                    expect(fetchSpy.args[0][0], 'should retrieve the IAB vendor list by default').to.equal(givenVendorListLocation)
+                })
+                .then(() => done())
+                .catch(e => done(e))
+        })
+    })
+})


### PR DESCRIPTION
This PR includes the base implementation for the GetVendorList use case

* simple logic of the use case until we can read the stored consent string
* it just retrieves the remote global vendor list

![](https://media.giphy.com/media/xUOwGgxZLBmqB87sic/giphy.gif)