### PR TITLE
Feature/minimal refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,6 +1450,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -1776,6 +1781,14 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "consent-string": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/consent-string/-/consent-string-1.2.4.tgz",
+      "integrity": "sha512-qrU2xdTWxLfoS8k8CYgv1TDODSGd/gLopZfCff4KZ1+hsJaCLi4PsrlqqdN6x+MxsU4BoRoHkOSC2dGjXuQzjQ==",
+      "requires": {
+        "base-64": "^0.1.0"
       }
     },
     "contains-path": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     ]
   },
   "dependencies": {
+    "consent-string": "^1.2.4",
     "whatwg-fetch": "^2.0.4"
   }
 }

--- a/src/cmp/infrastructure/repository/CookieConsentRepository.js
+++ b/src/cmp/infrastructure/repository/CookieConsentRepository.js
@@ -2,9 +2,9 @@
  * @class
  * @implements ConsentRepository
  */
-export default class LocalConsentRepository {
-  constructor({document}) {
-    this._document = document
+export default class CookieConsentRepository {
+  constructor({dom}) {
+    this._dom = dom
   }
 
   getConsentData() {
@@ -15,7 +15,7 @@ export default class LocalConsentRepository {
   }
 
   _readCookie(name) {
-    const value = `; ${this._document.cookie}`
+    const value = `; ${this._dom.cookie}`
     const parts = value.split(`; ${name}=`)
     if (parts.length === 2) {
       return parts

--- a/src/cmp/infrastructure/repository/CookieConsentRepository.js
+++ b/src/cmp/infrastructure/repository/CookieConsentRepository.js
@@ -8,21 +8,23 @@ export default class CookieConsentRepository {
   }
 
   getConsentData() {
-    return Promise.resolve().then(() => {
-      const cookie = this._readCookie(VENDOR_CONSENT_COOKIE_NAME)
-      return cookie
-    })
+    return Promise.resolve().then(() =>
+      this._readCookie({cookieName: VENDOR_CONSENT_COOKIE_NAME})
+    )
   }
 
-  _readCookie(name) {
-    const value = `; ${this._dom.cookie}`
-    const parts = value.split(`; ${name}=`)
-    if (parts.length === 2) {
-      return parts
-        .pop()
-        .split(';')
-        .shift()
-    }
+  _readCookie({cookieName}) {
+    return Promise.resolve()
+      .then(() => `; ${this._dom.cookie}`.split(`; ${cookieName}=`))
+      .then(
+        cookieParts =>
+          (cookieParts.length === 2 &&
+            cookieParts
+              .pop()
+              .split(';')
+              .shift()) ||
+          undefined
+      )
   }
 }
 const VENDOR_CONSENT_COOKIE_NAME = 'euconsent'

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import IABConsentManagementProviderV1 from './cmp/infrastructure/controller/IABC
 import commandConsumer from './cmp/infrastructure/controller/commandConsumer'
 import PingUseCase from './cmp/application/PingUseCase'
 import GetConsentDataUseCase from './cmp/application/GetConsentDataUseCase'
-import LocalConsentRepository from './cmp/infrastructure/repository/LocalConsentRepository'
+import CookieConsentRepository from './cmp/infrastructure/repository/CookieConsentRepository'
 
 const log = new Log({console})
 
@@ -12,8 +12,8 @@ const DEFAULT_GDPR_APPLIES = true
 const DEFAULT_HAS_GLOBAL_SCOPE = false
 
 // Resolve dependencies
-const consentRepository = new LocalConsentRepository({
-  document: window.document
+const consentRepository = new CookieConsentRepository({
+  dom: window.document
 })
 
 // Supported use cases

--- a/test/cmp/infrastructure/repository/CookieConsentRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/CookieConsentRepositoryTest.js
@@ -33,7 +33,7 @@ describe('CookieConsentRepository test', () => {
 
       repository.getConsentData()
         .then(result => {
-          expect(result, 'result should be the expected consent data from the cookie').to.deep.equal(undefined)
+          expect(result, 'result should be the expected consent data from the cookie').to.undefined
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/repository/CookieConsentRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/CookieConsentRepositoryTest.js
@@ -1,8 +1,8 @@
 /* eslint-disable prettier/prettier */
-import LocalConsentRepository from '../../../../src/cmp/infrastructure/repository/LocalConsentRepository'
 import {expect} from 'chai'
+import CookieConsentRepository from '../../../../src/cmp/infrastructure/repository/CookieConsentRepository'
 
-describe('LocalConsentRepository test', () => {
+describe('CookieConsentRepository test', () => {
   describe('getConsentData method', () => {
     it('Should return the consent data from vendor cookie', done => {
       const expectedEuconsent = 'BOPVloMOPi60FABABAENBA-AAAAcF7_______9______9uz_Gv_r_f__33e8_39v_h_7_-___m_-3zV4-_lvR11yPA1OrfIrwFhiAwAA'
@@ -11,11 +11,11 @@ describe('LocalConsentRepository test', () => {
         cookie: givenCookieValue
       }
 
-      const localConsentRepository = new LocalConsentRepository({
-        document: documentMock
+      const repository = new CookieConsentRepository({
+        dom: documentMock
       })
 
-      localConsentRepository.getConsentData()
+      repository.getConsentData()
         .then(result => {
           expect(result, 'result should be the expected consent data from the cookie').to.deep.equal(expectedEuconsent)
          })
@@ -27,11 +27,11 @@ describe('LocalConsentRepository test', () => {
         cookie: ""
       }
 
-      const localConsentRepository = new LocalConsentRepository({
-        document: documentMock
+      const repository = new CookieConsentRepository({
+        dom: documentMock
       })
 
-      localConsentRepository.getConsentData()
+      repository.getConsentData()
         .then(result => {
           expect(result, 'result should be the expected consent data from the cookie').to.deep.equal(undefined)
         })


### PR DESCRIPTION
* renamed LocalConsentRepository to CookieConsentRepository as it has to deal with global consents too
* now _readCookie returns a promise
* added consent-string sdk for next iterations