### PR TITLE
Feature/get vendors consent use case

### DIFF
--- a/src/cmp/application/GetVendorConsentsUseCase.js
+++ b/src/cmp/application/GetVendorConsentsUseCase.js
@@ -12,13 +12,13 @@ export default class GetVendorConsentsUseCase {
     this._consentFactory = consentFactory
     this._vendorConsentsFactory = vendorConsentsFactory
   }
-  getVendorConsents({vendorIds}) {
+  getVendorConsents({vendorIds} = {}) {
     return Promise.resolve()
       .then(() =>
         Promise.all([
           this._consentRepository
             .getConsentData()
-            .then(consentString => this._filterConsentMustExist),
+            .then(this._filterConsentMustExist),
           this._vendorRepository.getGlobalVendorList()
         ])
       )

--- a/src/cmp/application/GetVendorConsentsUseCase.js
+++ b/src/cmp/application/GetVendorConsentsUseCase.js
@@ -1,0 +1,44 @@
+import UnexistingConsentDataError from '../domain/UnexistingConsentDataError'
+
+export default class GetVendorConsentsUseCase {
+  constructor({
+    consentRepository,
+    vendorRepository,
+    consentFactory,
+    vendorConsentsFactory
+  }) {
+    this._consentRepository = consentRepository
+    this._vendorRepository = vendorRepository
+    this._consentFactory = consentFactory
+    this._vendorConsentsFactory = vendorConsentsFactory
+  }
+  getVendorConsents({vendorIds}) {
+    return Promise.resolve()
+      .then(() =>
+        Promise.all([
+          this._consentRepository
+            .getConsentData()
+            .then(consentString => this._filterConsentMustExist),
+          this._vendorRepository.getGlobalVendorList()
+        ])
+      )
+      .then(([consentString, globalVendorList]) =>
+        this._consentFactory
+          .createConsent({consentString, globalVendorList})
+          .then(consent =>
+            this._vendorConsentsFactory.createVendorConsents({
+              consent,
+              globalVendorList,
+              allowedVendorIds: vendorIds
+            })
+          )
+      )
+  }
+
+  _filterConsentMustExist(consent) {
+    if (!consent) {
+      throw new UnexistingConsentDataError()
+    }
+    return consent
+  }
+}

--- a/src/cmp/domain/ConsentFactory.js
+++ b/src/cmp/domain/ConsentFactory.js
@@ -1,0 +1,12 @@
+import {ConsentString} from 'consent-string'
+
+export default class ConsentFactory {
+  createConsent({consentString, globalVendorList}) {
+    return Promise.resolve()
+      .then(() => new ConsentString(consentString))
+      .then(consent => {
+        consent.setGlobalVendorList(globalVendorList)
+        return consent
+      })
+  }
+}

--- a/src/cmp/domain/ConsentFactory.js
+++ b/src/cmp/domain/ConsentFactory.js
@@ -1,12 +1,8 @@
-import {ConsentString} from 'consent-string'
-
+/**
+ * @interface
+ */
 export default class ConsentFactory {
   createConsent({consentString, globalVendorList}) {
-    return Promise.resolve()
-      .then(() => new ConsentString(consentString))
-      .then(consent => {
-        consent.setGlobalVendorList(globalVendorList)
-        return consent
-      })
+    throw new Error('ConsentFactory#createConsent must be implemented')
   }
 }

--- a/src/cmp/domain/UnexistingConsentDataError.js
+++ b/src/cmp/domain/UnexistingConsentDataError.js
@@ -1,0 +1,8 @@
+export default class UnexistingConsentDataError extends Error {
+  constructor() {
+    super()
+    this.name = 'UnexistingConsentDataError'
+    this.message = `Consent Data has not been set yet`
+    this.stack = new Error().stack
+  }
+}

--- a/src/cmp/domain/VendorConsents.js
+++ b/src/cmp/domain/VendorConsents.js
@@ -27,13 +27,13 @@
 export default class VendorConsents {
   constructor({
     metadata,
-    gdrpApplies,
+    gdprApplies,
     hasGlobalScope,
     purposeConsents,
     vendorConsents
   }) {
     this._metadata = metadata
-    this._gdrpApplies = gdrpApplies
+    this._gdprApplies = gdprApplies
     this._hasGlobalScope = hasGlobalScope
     this._purposeConsents = purposeConsents
     this._vendorConsents = vendorConsents
@@ -43,8 +43,8 @@ export default class VendorConsents {
     return this._metadata
   }
 
-  get gdrpApplies() {
-    return this._gdrpApplies
+  get gdprApplies() {
+    return this._gdprApplies
   }
 
   get hasGlobalScope() {

--- a/src/cmp/domain/VendorConsents.js
+++ b/src/cmp/domain/VendorConsents.js
@@ -1,0 +1,61 @@
+/**
+ * This object contains the global purposes, and vendors, consented to by the user:
+{
+  metadata: [base64url-encoded](https://tools.ietf.org/html/rfc4648#section-5) string (header data from the vendor consent format, as described below),
+  gdprApplies: *Boolean*,
+  hasGlobalScope: *Boolean,  // true if the vendor consent data is retrieved from the global cookie, false if a publisher-specific (or publisher-group-specific) cookie*
+  purposeConsents: {
+    *purposeId*: *consentBoolean*,
+    ?
+  },
+  vendorConsents: {
+    *vendorId* : *c**onsentBoolean*,
+    ?
+  },
+}
+
+ where vendorId and purposeId are the keys and *consentBoolean *are the values for the consent (false="No Consent?, true=?Consent?). The *gdprApplies *field will be true if the user is determined (by geo-IP lookup) to be in the EU, or the publisher has configured the CMP (via a CMP-specific method not specified by this spec) that they are a EU publisher and thus the CMP UI should be shown for everyone. The metadata will be the base64url-encoded value of the following "header" information described in the cookie format:
+ -Cookie Version
+ -Created Timestamp
+ -Last Updated Timestamp
+ -Cmp Id
+ -Cmp Version
+ -Consent Screen
+ -Vendor List Version
+ -Publisher Purposes Version (for the PublisherConsent metadata only)
+ */
+export default class VendorConsents {
+  constructor({
+    metadata,
+    gdrpApplies,
+    hasGlobalScope,
+    purposeConsents,
+    vendorConsents
+  }) {
+    this._metadata = metadata
+    this._gdrpApplies = gdrpApplies
+    this._hasGlobalScope = hasGlobalScope
+    this._purposeConsents = purposeConsents
+    this._vendorConsents = vendorConsents
+  }
+
+  get metadata() {
+    return this._metadata
+  }
+
+  get gdrpApplies() {
+    return this._gdrpApplies
+  }
+
+  get hasGlobalScope() {
+    return this._hasGlobalScope
+  }
+
+  get purposeConsents() {
+    return this._purposeConsents
+  }
+
+  get vendorConsents() {
+    return this._vendorConsents
+  }
+}

--- a/src/cmp/domain/VendorConsentsFactory.js
+++ b/src/cmp/domain/VendorConsentsFactory.js
@@ -1,41 +1,10 @@
-import VendorConsents from './VendorConsents'
-
+/**
+ * @interface
+ */
 export default class VendorConsentsFactory {
-  constructor({gdprApplies, storeConsentGlobally}) {
-    this._gdprApplies = gdprApplies
-    this._storeConsentGlobally = storeConsentGlobally
-  }
-  createVendorConsents({consent, globalVendorList, allowedVendorIds} = {}) {
-    return Promise.resolve().then(() =>
-      Promise.all([
-        Promise.resolve(
-          allowedVendorIds || globalVendorList.vendors.map(v => v.id)
-        ).then(vendorIds => {
-          let vendorConsents = {}
-          vendorIds.forEach(id => {
-            vendorConsents.id = consent.isVendorAllowed(id)
-          })
-          return vendorConsents
-        }),
-        Promise.resolve(globalVendorList.purposes.map(p => p.id)).then(
-          purposeIds => {
-            let purposeConsents = {}
-            purposeIds.forEach(id => {
-              purposeConsents.id = consent.isPurposeAllowed(id)
-            })
-            return purposeConsents
-          }
-        )
-      ]).then(
-        ([vendorConsents, purposeConsents]) =>
-          new VendorConsents({
-            gdrpApplies: this._gdprApplies,
-            hasGlobalScope: this._storeConsentGlobally,
-            metadata: consent.getMetadataString(),
-            vendorConsents,
-            purposeConsents
-          })
-      )
+  createVendorConsents({consent, globalVendorList, allowedVendorIds}) {
+    throw new Error(
+      'VendorConsentsFactory#createVendorConsents must be implemented'
     )
   }
 }

--- a/src/cmp/domain/VendorConsentsFactory.js
+++ b/src/cmp/domain/VendorConsentsFactory.js
@@ -1,0 +1,41 @@
+import VendorConsents from './VendorConsents'
+
+export default class VendorConsentsFactory {
+  constructor({gdprApplies, storeConsentGlobally}) {
+    this._gdprApplies = gdprApplies
+    this._storeConsentGlobally = storeConsentGlobally
+  }
+  createVendorConsents({consent, globalVendorList, allowedVendorIds} = {}) {
+    return Promise.resolve().then(() =>
+      Promise.all([
+        Promise.resolve(
+          allowedVendorIds || globalVendorList.vendors.map(v => v.id)
+        ).then(vendorIds => {
+          let vendorConsents = {}
+          vendorIds.forEach(id => {
+            vendorConsents.id = consent.isVendorAllowed(id)
+          })
+          return vendorConsents
+        }),
+        Promise.resolve(globalVendorList.purposes.map(p => p.id)).then(
+          purposeIds => {
+            let purposeConsents = {}
+            purposeIds.forEach(id => {
+              purposeConsents.id = consent.isPurposeAllowed(id)
+            })
+            return purposeConsents
+          }
+        )
+      ]).then(
+        ([vendorConsents, purposeConsents]) =>
+          new VendorConsents({
+            gdrpApplies: this._gdprApplies,
+            hasGlobalScope: this._storeConsentGlobally,
+            metadata: consent.getMetadataString(),
+            vendorConsents,
+            purposeConsents
+          })
+      )
+    )
+  }
+}

--- a/src/cmp/infrastructure/factory/IABConsentFactory.js
+++ b/src/cmp/infrastructure/factory/IABConsentFactory.js
@@ -1,0 +1,16 @@
+import {ConsentString} from 'consent-string'
+
+/**
+ * @class
+ * @implements ConsentFactory
+ */
+export default class IABConsentFactory {
+  createConsent({consentString, globalVendorList}) {
+    return Promise.resolve()
+      .then(() => new ConsentString(consentString))
+      .then(consent => {
+        consent.setGlobalVendorList(globalVendorList)
+        return consent
+      })
+  }
+}

--- a/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
+++ b/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
@@ -40,7 +40,7 @@ export default class IABVendorConsentsFactory {
       ]).then(
         ([vendorConsents, purposeConsents]) =>
           new VendorConsents({
-            gdrpApplies: this._gdprApplies,
+            gdprApplies: this._gdprApplies,
             hasGlobalScope: this._storeConsentGlobally,
             metadata: consent.getMetadataString(),
             vendorConsents,

--- a/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
+++ b/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
@@ -1,0 +1,45 @@
+import VendorConsents from '../../domain/VendorConsents'
+
+/**
+ * @class
+ * @implements VendorConsentsFactory
+ */
+export default class IABVendorConsentsFactory {
+  constructor({gdprApplies, storeConsentGlobally}) {
+    this._gdprApplies = gdprApplies
+    this._storeConsentGlobally = storeConsentGlobally
+  }
+  createVendorConsents({consent, globalVendorList, allowedVendorIds} = {}) {
+    return Promise.resolve().then(() =>
+      Promise.all([
+        Promise.resolve(
+          allowedVendorIds || globalVendorList.vendors.map(v => v.id)
+        ).then(vendorIds => {
+          let vendorConsents = {}
+          vendorIds.forEach(id => {
+            vendorConsents.id = consent.isVendorAllowed(id)
+          })
+          return vendorConsents
+        }),
+        Promise.resolve(globalVendorList.purposes.map(p => p.id)).then(
+          purposeIds => {
+            let purposeConsents = {}
+            purposeIds.forEach(id => {
+              purposeConsents.id = consent.isPurposeAllowed(id)
+            })
+            return purposeConsents
+          }
+        )
+      ]).then(
+        ([vendorConsents, purposeConsents]) =>
+          new VendorConsents({
+            gdrpApplies: this._gdprApplies,
+            hasGlobalScope: this._storeConsentGlobally,
+            metadata: consent.getMetadataString(),
+            vendorConsents,
+            purposeConsents
+          })
+      )
+    )
+  }
+}

--- a/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
+++ b/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
@@ -12,19 +12,22 @@ export default class IABVendorConsentsFactory {
   createVendorConsents({consent, globalVendorList, allowedVendorIds} = {}) {
     return Promise.resolve().then(() =>
       Promise.all([
-        Promise.resolve(
-          (allowedVendorIds &&
-            globalVendorList.vendors
-              .map(v => v.id)
-              .filter(id => allowedVendorIds.indexOf(id) !== -1)) ||
-            globalVendorList.vendors.map(v => v.id)
-        ).then(vendorIds => {
-          let vendorConsents = {}
-          vendorIds.forEach(id => {
-            vendorConsents[id] = consent.isVendorAllowed(id)
-          })
-          return vendorConsents
-        }),
+        Promise.resolve()
+          .then(
+            () =>
+              (allowedVendorIds &&
+                globalVendorList.vendors
+                  .map(v => v.id)
+                  .filter(id => allowedVendorIds.indexOf(id) !== -1)) ||
+              globalVendorList.vendors.map(v => v.id)
+          )
+          .then(vendorIds => {
+            let vendorConsents = {}
+            vendorIds.forEach(id => {
+              vendorConsents[id] = consent.isVendorAllowed(id)
+            })
+            return vendorConsents
+          }),
         Promise.resolve(globalVendorList.purposes.map(p => p.id)).then(
           purposeIds => {
             let purposeConsents = {}

--- a/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
+++ b/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
@@ -5,7 +5,7 @@ import VendorConsents from '../../domain/VendorConsents'
  * @implements VendorConsentsFactory
  */
 export default class IABVendorConsentsFactory {
-  constructor({gdprApplies, storeConsentGlobally}) {
+  constructor({gdprApplies = true, storeConsentGlobally = false} = {}) {
     this._gdprApplies = gdprApplies
     this._storeConsentGlobally = storeConsentGlobally
   }
@@ -13,7 +13,11 @@ export default class IABVendorConsentsFactory {
     return Promise.resolve().then(() =>
       Promise.all([
         Promise.resolve(
-          allowedVendorIds || globalVendorList.vendors.map(v => v.id)
+          (allowedVendorIds &&
+            globalVendorList.vendors
+              .map(v => v.id)
+              .filter(id => allowedVendorIds.indexOf(id) !== -1)) ||
+            globalVendorList.vendors.map(v => v.id)
         ).then(vendorIds => {
           let vendorConsents = {}
           vendorIds.forEach(id => {

--- a/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
+++ b/src/cmp/infrastructure/factory/IABVendorConsentsFactory.js
@@ -17,7 +17,7 @@ export default class IABVendorConsentsFactory {
         ).then(vendorIds => {
           let vendorConsents = {}
           vendorIds.forEach(id => {
-            vendorConsents.id = consent.isVendorAllowed(id)
+            vendorConsents[id] = consent.isVendorAllowed(id)
           })
           return vendorConsents
         }),
@@ -25,7 +25,7 @@ export default class IABVendorConsentsFactory {
           purposeIds => {
             let purposeConsents = {}
             purposeIds.forEach(id => {
-              purposeConsents.id = consent.isPurposeAllowed(id)
+              purposeConsents[id] = consent.isPurposeAllowed(id)
             })
             return purposeConsents
           }

--- a/test/cmp/application/GetVendorConsentsUseCaseTest.js
+++ b/test/cmp/application/GetVendorConsentsUseCaseTest.js
@@ -1,0 +1,128 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import {ConsentString} from 'consent-string'
+import GetVendorConsentsUseCase from '../../../src/cmp/application/GetVendorConsentsUseCase'
+import VendorConsents from '../../../src/cmp/domain/VendorConsents'
+
+describe('Get Vendor Consents Use Case', () => {
+  it('Should create the VendorConsents using the stored consent and the global vendor list', done => {
+    const aConsentString =
+      'BOPVloMOPi60FABABAENBA-AAAAcF7_______9______9uz_Gv_r_f__33e8_39v_h_7_-___m_-3zV4-_lvR11yPA1OrfIrwFhiAwAA'
+    const aGlobalVendorList = require('./../resources/globalvendorlist.json')
+    const aConsentObject = new ConsentString(aConsentString)
+    const aAllowedVendorIds = [1]
+    const aVendorConsentsObject = new VendorConsents({
+      metadata: 'JUST FOR TEST'
+    })
+    const consentRepositoryMock = {
+      getConsentData: () => Promise.resolve(aConsentString)
+    }
+    const vendorRepositoryMock = {
+      getGlobalVendorList: () => Promise.resolve(aGlobalVendorList)
+    }
+    const consentFactoryMock = {
+      createConsent: () => Promise.resolve(aConsentObject)
+    }
+    const vendorConsentsFactoryMock = {
+      createVendorConsents: () => Promise.resolve(aVendorConsentsObject)
+    }
+
+    const useCase = new GetVendorConsentsUseCase({
+      consentRepository: consentRepositoryMock,
+      vendorRepository: vendorRepositoryMock,
+      consentFactory: consentFactoryMock,
+      vendorConsentsFactory: vendorConsentsFactoryMock
+    })
+
+    const getConsentDataSpy = sinon.spy(consentRepositoryMock, 'getConsentData')
+    const getGlobalVendorListSpy = sinon.spy(
+      vendorRepositoryMock,
+      'getGlobalVendorList'
+    )
+    const createConsentSpy = sinon.spy(consentFactoryMock, 'createConsent')
+    const createVendorConsentsSpy = sinon.spy(
+      vendorConsentsFactoryMock,
+      'createVendorConsents'
+    )
+
+    useCase
+      .getVendorConsents({vendorIds: aAllowedVendorIds})
+      .then(vendorConsents => {
+        expect(
+          getConsentDataSpy.calledOnce,
+          'should have tried to get the stored consent data'
+        ).to.be.true
+        expect(
+          getGlobalVendorListSpy.calledOnce,
+          'should have tried to get the global vendor list'
+        ).to.be.true
+        expect(
+          createConsentSpy.calledOnce,
+          'should create the consent object using the factory'
+        ).to.be.true
+        expect(
+          createVendorConsentsSpy.calledOnce,
+          'should create the vendor consents object using the factory'
+        ).to.be.true
+
+        expect(
+          [
+            createConsentSpy.args[0][0].consentString,
+            createConsentSpy.args[0][0].globalVendorList
+          ],
+          'should create the consent object using the consent string and the global vendor list'
+        ).to.deep.equal([aConsentString, aGlobalVendorList])
+
+        expect(
+          [
+            createVendorConsentsSpy.args[0][0].consent,
+            createVendorConsentsSpy.args[0][0].globalVendorList,
+            createVendorConsentsSpy.args[0][0].allowedVendorIds
+          ],
+          'should create the vendor consents using the stored consent, the global vendor list and the allowed vendor ids array'
+        ).to.deep.equal([aConsentObject, aGlobalVendorList, aAllowedVendorIds])
+
+        expect(
+          vendorConsents,
+          'should return the object returned by the factory'
+        ).to.deep.equal(aVendorConsentsObject)
+      })
+      .then(() => done())
+      .catch(e => done(e))
+  })
+  it('Should throw an UnexistingConsentDataError if there is no consent', done => {
+    const consentRepositoryMock = {
+      getConsentData: () => Promise.resolve(undefined)
+    }
+    const vendorRepositoryMock = {
+      getGlobalVendorList: () => Promise.resolve()
+    }
+    const consentFactoryMock = {
+      createConsent: () => Promise.resolve()
+    }
+    const vendorConsentsFactoryMock = {
+      createVendorConsents: () => Promise.resolve()
+    }
+
+    const useCase = new GetVendorConsentsUseCase({
+      consentRepository: consentRepositoryMock,
+      vendorRepository: vendorRepositoryMock,
+      consentFactory: consentFactoryMock,
+      vendorConsentsFactory: vendorConsentsFactoryMock
+    })
+
+    useCase
+      .getVendorConsents({})
+      .then(() =>
+        done(new Error('Should have throw an UnexistingConsentDataError'))
+      )
+      .catch(e => {
+        expect(
+          e.name,
+          'Should have throw an UnexistingConsentDataError'
+        ).to.equal('UnexistingConsentDataError')
+        done()
+      })
+      .catch(e => done(e))
+  })
+})

--- a/test/cmp/infrastructure/factory/IABConsentFactoryTest.js
+++ b/test/cmp/infrastructure/factory/IABConsentFactoryTest.js
@@ -1,0 +1,22 @@
+/* eslint-disable prettier/prettier */
+import {expect} from 'chai'
+import IABConsentFactory from "../../../../src/cmp/infrastructure/factory/IABConsentFactory";
+
+describe('IAB Consent Factory', () => {
+    describe('createConsent method', () => {
+        it('Should return a ConsentString with a globalVendorList', done => {
+            const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
+            const givenConsentStringData = 'BOPVloMOPi60FABABAENBA-AAAAcF7_______9______9uz_Gv_r_f__33e8_39v_h_7_-___m_-3zV4-_lvR11yPA1OrfIrwFhiAwAA'
+            const factory = new IABConsentFactory()
+            factory.createConsent({
+                consentString: givenConsentStringData,
+                globalVendorList: givenGlobalVendorList
+            }).then(consent => {
+                expect(consent.getVendorListVersion(), 'consent has no valid vendor list version').to.equal(67)
+                expect(consent.getCmpId(), 'consent has not parsed the string data').to.equal(1)
+            })
+            .then(() => done())
+            .catch(e => done(e))
+        })
+    })
+})

--- a/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
+++ b/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
@@ -109,7 +109,10 @@ describe('IAB VendorConsents Factory', () => {
         )
         .then(metadata => {
           expect(metadata.cmpId, 'Metadata has invalid cmpId').to.equal(1)
-          expect(metadata.vendorListVersion, 'Metadata has invalid vendorListVersion').to.equal(givenGlobalVendorList.vendorListVersion)
+          expect(
+            metadata.vendorListVersion,
+            'Metadata has invalid vendorListVersion'
+          ).to.equal(givenGlobalVendorList.vendorListVersion)
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
+++ b/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
@@ -62,7 +62,7 @@ describe('IAB VendorConsents Factory', () => {
       const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
       const givenPurposesAllowed = [1, 2]
       const givenVendorsAllowed = [1, 6]
-      const givenAllowedVendorsIds = [1, 5, 6]
+      const givenAllowedVendorIds = [1, 5, 6]
 
       const givenConsent = new ConsentString()
       givenConsent.setPurposesAllowed(givenPurposesAllowed)
@@ -77,13 +77,39 @@ describe('IAB VendorConsents Factory', () => {
         .createVendorConsents({
           globalVendorList: givenGlobalVendorList,
           consent: givenConsent,
-          allowedVendorIds: givenAllowedVendorsIds
+          allowedVendorIds: givenAllowedVendorIds
         })
         .then(vendorConsents => {
           expect(
             Object.keys(vendorConsents.vendorConsents).length,
             'the vendor consents should contain 2 elements'
           ).to.be.equal(2)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should return the appropiate metadata info into the consents object', done => {
+      const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
+
+      const givenConsent = new ConsentString()
+      givenConsent.setGlobalVendorList(givenGlobalVendorList)
+      givenConsent.setCmpId(1)
+      givenConsent.setCmpVersion(2)
+      givenConsent.setConsentScreen(3)
+
+      const factory = new IABVendorConsentsFactory()
+
+      factory
+        .createVendorConsents({
+          globalVendorList: givenGlobalVendorList,
+          consent: givenConsent
+        })
+        .then(vendorConsents =>
+          ConsentString.decodeMetadataString(vendorConsents.metadata)
+        )
+        .then(metadata => {
+          expect(metadata.cmpId, 'Metadata has invalid cmpId').to.equal(1)
+          expect(metadata.vendorListVersion, 'Metadata has invalid vendorListVersion').to.equal(givenGlobalVendorList.vendorListVersion)
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
+++ b/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
@@ -4,12 +4,12 @@ import IABVendorConsentsFactory from '../../../../src/cmp/infrastructure/factory
 
 describe('IAB VendorConsents Factory', () => {
   describe('createVendorConsents method', () => {
-    it('Should return a VendorConsents with vendor and purpose consent values', done => {
+    it('Should return a VendorConsents with all vendors and purposes if no ids restriction is set', done => {
       const givenGdprApplies = true
       const givenStoreConsentGlobally = false
       const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
       const givenPurposesAllowed = [1, 2]
-      const givenVendorsAllowed = [1, 5]
+      const givenVendorsAllowed = [1, 6]
 
       const givenConsent = new ConsentString()
       givenConsent.setPurposesAllowed(givenPurposesAllowed)
@@ -26,6 +26,14 @@ describe('IAB VendorConsents Factory', () => {
           consent: givenConsent
         })
         .then(vendorConsents => {
+          expect(
+            Object.keys(vendorConsents.vendorConsents).length,
+            'the vendor consents should contain an entry for each vendor in the global list'
+          ).to.be.equal(givenGlobalVendorList.vendors.length)
+          expect(
+            Object.keys(vendorConsents.purposeConsents).length,
+            'the purpose consents should contain an entry for each vendor in the global list'
+          ).to.be.equal(givenGlobalVendorList.purposes.length)
           givenGlobalVendorList.vendors.forEach(v => {
             const condition = givenVendorsAllowed.includes(v.id)
             expect(
@@ -44,6 +52,38 @@ describe('IAB VendorConsents Factory', () => {
               } should be ${condition}`
             ).to.equal(condition)
           })
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should return a VendorConsents with only the existing vendors included in the given vendorIds', done => {
+      const givenGdprApplies = true
+      const givenStoreConsentGlobally = false
+      const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
+      const givenPurposesAllowed = [1, 2]
+      const givenVendorsAllowed = [1, 6]
+      const givenAllowedVendorsIds = [1, 5, 6]
+
+      const givenConsent = new ConsentString()
+      givenConsent.setPurposesAllowed(givenPurposesAllowed)
+      givenConsent.setVendorsAllowed(givenVendorsAllowed)
+
+      const factory = new IABVendorConsentsFactory({
+        gdprApplies: givenGdprApplies,
+        storeConsentGlobally: givenStoreConsentGlobally
+      })
+
+      factory
+        .createVendorConsents({
+          globalVendorList: givenGlobalVendorList,
+          consent: givenConsent,
+          allowedVendorIds: givenAllowedVendorsIds
+        })
+        .then(vendorConsents => {
+          expect(
+            Object.keys(vendorConsents.vendorConsents).length,
+            'the vendor consents should contain 2 elements'
+          ).to.be.equal(2)
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
+++ b/test/cmp/infrastructure/factory/IABVendorConsentsFactoryTest.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai'
+import {ConsentString} from 'consent-string'
+import IABVendorConsentsFactory from '../../../../src/cmp/infrastructure/factory/IABVendorConsentsFactory'
+
+describe('IAB VendorConsents Factory', () => {
+  describe('createVendorConsents method', () => {
+    it('Should return a VendorConsents with vendor and purpose consent values', done => {
+      const givenGdprApplies = true
+      const givenStoreConsentGlobally = false
+      const givenGlobalVendorList = require('./../../resources/globalvendorlist.json')
+      const givenPurposesAllowed = [1, 2]
+      const givenVendorsAllowed = [1, 5]
+
+      const givenConsent = new ConsentString()
+      givenConsent.setPurposesAllowed(givenPurposesAllowed)
+      givenConsent.setVendorsAllowed(givenVendorsAllowed)
+
+      const factory = new IABVendorConsentsFactory({
+        gdprApplies: givenGdprApplies,
+        storeConsentGlobally: givenStoreConsentGlobally
+      })
+
+      factory
+        .createVendorConsents({
+          globalVendorList: givenGlobalVendorList,
+          consent: givenConsent
+        })
+        .then(vendorConsents => {
+          givenGlobalVendorList.vendors.forEach(v => {
+            const condition = givenVendorsAllowed.includes(v.id)
+            expect(
+              vendorConsents.vendorConsents[v.id],
+              `The vendor consent ${
+                vendorConsents.vendorConsents[v.id]
+              } should be ${condition}`
+            ).to.equal(condition)
+          })
+          givenGlobalVendorList.purposes.forEach(p => {
+            const condition = givenPurposesAllowed.includes(p.id)
+            expect(
+              vendorConsents.purposeConsents[p.id],
+              `The purpose consent ${
+                vendorConsents.purposeConsents[p.id]
+              } should be ${condition}`
+            ).to.equal(condition)
+          })
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+  })
+})

--- a/test/cmp/resources/globalvendorlist.json
+++ b/test/cmp/resources/globalvendorlist.json
@@ -1,0 +1,5373 @@
+{
+  "vendorListVersion": 67,
+  "lastUpdated": "2018-06-20T16:00:16Z",
+  "purposes": [
+    {
+      "id": 1,
+      "name": "Information storage and access",
+      "description": "The storage of information, or access to information that is already stored, on your device such as advertising identifiers, device identifiers, cookies, and similar technologies."
+    },
+    {
+      "id": 2,
+      "name": "Personalisation",
+      "description": "The collection and processing of information about your use of this service to subsequently personalise advertising and/or content for you in other contexts, such as on other websites or apps, over time. Typically, the content of the site or app is used to make inferences about your interests, which inform future selection of advertising and/or content."
+    },
+    {
+      "id": 3,
+      "name": "Ad selection, delivery, reporting",
+      "description": "The collection of information, and combination with previously collected information, to select and deliver advertisements for you, and to measure the delivery and effectiveness of such advertisements. This includes using previously collected information about your interests to select ads, processing data about what advertisements were shown, how often they were shown, when and where they were shown, and whether you took any action related to the advertisement, including for example clicking an ad or making a purchase. This does not include personalisation, which is the collection and processing of information about your use of this service to subsequently personalise advertising and/or content for you in other contexts, such as websites or apps, over time."
+    },
+    {
+      "id": 4,
+      "name": "Content selection, delivery, reporting",
+      "description": "The collection of information, and combination with previously collected information, to select and deliver content for you, and to measure the delivery and effectiveness of such content. This includes using previously collected information about your interests to select content, processing data about what content was shown, how often or how long it was shown, when and where it was shown, and whether the you took any action related to the content, including for example clicking on content. This does not include personalisation, which is the collection and processing of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, such as websites or apps, over time."
+    },
+    {
+      "id": 5,
+      "name": "Measurement",
+      "description": "The collection of information about your use of the content, and combination with previously collected information, used to measure, understand, and report on your usage of the service. This does not include personalisation, the collection of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, i.e. on other service, such as websites or apps, over time."
+    }
+  ],
+  "features": [
+    {
+      "id": 1,
+      "name": "Matching Data to Offline Sources",
+      "description": "Combining data from offline sources that were initially collected in other contexts."
+    },
+    {
+      "id": 2,
+      "name": "Linking Devices",
+      "description": "Allow processing of a user's data to connect such user across multiple devices."
+    },
+    {
+      "id": 3,
+      "name": "Precise Geographic Location Data",
+      "description": "Allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent."
+    }
+  ],
+  "vendors": [
+    {
+      "id": 8,
+      "name": "Emerse Sverige AB",
+      "policyUrl": "https://www.emerse.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 12,
+      "name": "BeeswaxIO Corporation",
+      "policyUrl": "https://www.beeswax.com/privacy.html",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 28,
+      "name": "TripleLift, Inc.",
+      "policyUrl": "https://triplelift.com/privacy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 9,
+      "name": "AdMaxim Inc.",
+      "policyUrl": "http://www.admaxim.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 27,
+      "name": "ADventori SAS",
+      "policyUrl": "https://www.adventori.com/with-us/legal-notice/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 25,
+      "name": "Oath (EMEA) Limited",
+      "policyUrl": "https://policies.oath.com/ie/en/oath/privacy/index.html",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 26,
+      "name": "Venatus Media Limited",
+      "policyUrl": "https://www.venatusmedia.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 1,
+      "name": "Exponential Interactive, Inc",
+      "policyUrl": "http://exponential.com/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 6,
+      "name": "AdSpirit GmbH",
+      "policyUrl": "http://www.adspirit.de/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 30,
+      "name": "BidTheatre AB",
+      "policyUrl": "https://www.bidtheatre.com/privacy-policy",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 24,
+      "name": "Conversant Europe Ltd.",
+      "policyUrl": "https://www.conversantmedia.eu/legal/privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 29,
+      "name": "Etarget SE",
+      "policyUrl": "https://www.etarget.sk/privacy.php",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 39,
+      "name": "ADITION technologies AG",
+      "policyUrl": "adition.com/datenschutz",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 11,
+      "name": "Quantcast International Limited",
+      "policyUrl": "https://www.quantcast.com/privacy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 15,
+      "name": "Adikteev",
+      "policyUrl": "https://www.adikteev.com/eu/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 4,
+      "name": "Roq.ad GmbH",
+      "policyUrl": "https://www.roq.ad/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 7,
+      "name": "Vibrant Media Limited",
+      "policyUrl": "https://www.vibrantmedia.com/en/privacy-policy/",
+      "purposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 2,
+      "name": "Captify Technologies Limited",
+      "policyUrl": "http://www.captify.co.uk/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 37,
+      "name": "NEURAL.ONE",
+      "policyUrl": "https://web.neural.one/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 13,
+      "name": "Sovrn Holdings Inc",
+      "policyUrl": "https://www.sovrn.com/sovrn-privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 34,
+      "name": "NEORY GmbH",
+      "policyUrl": "https://www.neory.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 32,
+      "name": "AppNexus Inc.",
+      "policyUrl": "https://www.appnexus.com/en/company/platform-privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 10,
+      "name": "Index Exchange, Inc. ",
+      "policyUrl": "www.indexexchange.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 57,
+      "name": "ADARA MEDIA UNLIMITED",
+      "policyUrl": "https://adara.com/2018/04/10/adara-gdpr-faq/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 63,
+      "name": "Avocet Systems Limited",
+      "policyUrl": "http://www.avocet.io/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 51,
+      "name": "xAd, Inc. dba GroundTruth",
+      "policyUrl": "https://www.groundtruth.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 49,
+      "name": "Tradelab, SAS",
+      "policyUrl": "http://tradelab.com/en/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 45,
+      "name": "Smart Adserver",
+      "policyUrl": "http://smartadserver.com/company/privacy-policy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 52,
+      "name": "The Rubicon Project, Limited",
+      "policyUrl": "http://rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 35,
+      "name": "Purch Group, Inc.",
+      "policyUrl": "http://www.purch.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 71,
+      "name": "Dataxu, Inc. ",
+      "policyUrl": "https://www.dataxu.com/about-us/privacy/data-collection-platform/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 79,
+      "name": "MediaMath, Inc.",
+      "policyUrl": "http://www.mediamath.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 91,
+      "name": "Criteo SA",
+      "policyUrl": "https://www.criteo.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 85,
+      "name": "Crimtan Holdings Limited",
+      "policyUrl": "https://crimtan.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 16,
+      "name": "RTB House S.A.",
+      "policyUrl": "https://www.rtbhouse.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 86,
+      "name": "Scene Stealer Limited",
+      "policyUrl": "http://scenestealer.tv/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 94,
+      "name": "Blis Media Limited",
+      "policyUrl": "http://www.blis.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 73,
+      "name": "Simplifi Holdings Inc.",
+      "policyUrl": "https://www.simpli.fi/site-privacy-policy2/",
+      "purposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 67,
+      "name": "LifeStreet Corporation",
+      "policyUrl": "http://www.lifestreet.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 33,
+      "name": "ShareThis, Inc.",
+      "policyUrl": "http://www.sharethis.com/privacy/",
+      "purposeIds": [
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 20,
+      "name": "N Technologies Inc.",
+      "policyUrl": "https://n.rich/privacy-notice",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 55,
+      "name": "Madison Logic, Inc.",
+      "policyUrl": "https://www.madisonlogic.com/privacy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 53,
+      "name": "Sirdata",
+      "policyUrl": "https://www.sirdata.com/privacy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 69,
+      "name": "OpenX Software Ltd. and its affiliates",
+      "policyUrl": "https://www.openx.com/legal/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 98,
+      "name": "GroupM",
+      "policyUrl": "https://www.groupm.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 62,
+      "name": "Justpremium BV",
+      "policyUrl": "http://justpremium.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 19,
+      "name": "Intent Media, Inc.",
+      "policyUrl": "https://intentmedia.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 43,
+      "name": "Vdopia DBA Chocolate Platform",
+      "policyUrl": "https://chocolateplatform.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 36,
+      "name": "RhythmOne, LLC",
+      "policyUrl": "https://www.rhythmone.com/privacy-policy",
+      "purposeIds": [
+        5
+      ],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 80,
+      "name": "Sharethrough, Inc",
+      "policyUrl": "https://platform-cdn.sharethrough.com/privacy-policy",
+      "purposeIds": [
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 81,
+      "name": "PulsePoint, Inc.",
+      "policyUrl": "https://www.pulsepoint.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 23,
+      "name": "Amobee, Inc. ",
+      "policyUrl": "https://www.amobee.com/trust/privacy-guidelines",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 75,
+      "name": "M32 Media Inc",
+      "policyUrl": "https://m32.media/privacy-cookie-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 17,
+      "name": "Greenhouse Group BV (with its trademark LemonPI)",
+      "policyUrl": "https://www.lemonpi.io/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 61,
+      "name": "GumGum, Inc.",
+      "policyUrl": "https://gumgum.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 40,
+      "name": "Active Agent AG",
+      "policyUrl": "http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 76,
+      "name": "PubMatic, Inc.",
+      "policyUrl": "https://pubmatic.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 89,
+      "name": "Tapad, Inc. ",
+      "policyUrl": "https://www.tapad.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 46,
+      "name": "Skimbit Ltd",
+      "policyUrl": "https://skimlinks.com/pages/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 66,
+      "name": "adsquare GmbH",
+      "policyUrl": "www.adsquare.com/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 105,
+      "name": "Impression Desk Technologies Limited",
+      "policyUrl": "impressiondesk.com",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 41,
+      "name": "Adverline",
+      "policyUrl": "https://www.adverline.com/privacy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 3,
+      "name": "affilinet",
+      "policyUrl": "https://www.affili.net/de/footeritem/datenschutz",
+      "purposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 82,
+      "name": "Smaato, Inc.",
+      "policyUrl": "https://www.smaato.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 60,
+      "name": "Rakuten Marketing LLC",
+      "policyUrl": "https://rakutenmarketing.com/legal-notices/services-privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 70,
+      "name": "Yieldlab AG",
+      "policyUrl": "http://www.yieldlab.de/meta-navigation/datenschutz/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 50,
+      "name": "Adform A/S",
+      "policyUrl": "https://site.adform.com/privacy-policy-opt-out/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 48,
+      "name": "NetSuccess, s.r.o.",
+      "policyUrl": "https://www.inres.sk/pp/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 100,
+      "name": "Fifty Technology Limited",
+      "policyUrl": "https://fiftymedia.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 21,
+      "name": "The Trade Desk, Inc and affiliated companies",
+      "policyUrl": "https://www.thetradedesk.com/general/privacy-policy",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 110,
+      "name": "Hottraffic BV (DMA Institute)",
+      "policyUrl": "https://www.dma-institute.com/additional-information-for-data-subjects/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 42,
+      "name": "Taboola Europe Limited",
+      "policyUrl": "https://www.taboola.com/privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 112,
+      "name": "Maytrics GmbH",
+      "policyUrl": "https://maytrics.com/node/2",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 77,
+      "name": "comScore, Inc.",
+      "policyUrl": "https://www.comscore.com/About-comScore/Privacy-Policy",
+      "purposeIds": [
+        1,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 109,
+      "name": "LoopMe Ltd",
+      "policyUrl": "https://loopme.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 120,
+      "name": "Eyeota Ptd Ltd",
+      "policyUrl": "https://www.eyeota.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2
+      ],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 93,
+      "name": "Adloox SA",
+      "policyUrl": "http://adloox.com/disclaimer",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 132,
+      "name": "Teads ",
+      "policyUrl": "https://teads.tv/privacy-policy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 22,
+      "name": "admetrics GmbH",
+      "policyUrl": "https://admetrics.io/en/privacy_policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 102,
+      "name": "SlimCut Media SAS",
+      "policyUrl": "http://www.slimcutmedia.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 108,
+      "name": "Rich Audience",
+      "policyUrl": "https://richaudience.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 18,
+      "name": "Widespace AB",
+      "policyUrl": "https://www.widespace.com/legal/privacy-policy-notice/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 68,
+      "name": "Sizmek Technologies, Inc. ",
+      "policyUrl": "https://www.sizmek.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 122,
+      "name": "Avid Media Ltd",
+      "policyUrl": "http://www.avidglobalmedia.eu/privacy-policy.html",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 97,
+      "name": "LiveRamp, Inc.",
+      "policyUrl": "www.liveramp.com/service-privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 74,
+      "name": "Admotion SRL",
+      "policyUrl": "http://www.admotion.com/policy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 138,
+      "name": "ConnectAd Realtime GmbH",
+      "policyUrl": "http://connectadrealtime.com/privacy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 95,
+      "name": "Lotame Solutions, Inc.",
+      "policyUrl": "https://www.lotame.com/about-lotame/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 72,
+      "name": "Nano Interactive GmbH",
+      "policyUrl": "http://www.nanointeractive.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 127,
+      "name": "PIXIMEDIA SAS",
+      "policyUrl": "https://piximedia.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 136,
+      "name": "Ströer SSP GmbH",
+      "policyUrl": "https://www.stroeer.de/fileadmin/user_upload/Datenschutz.pdf",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 111,
+      "name": "ShowHeroes GmbH",
+      "policyUrl": "http://showheroes.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 56,
+      "name": "Confiant Inc.",
+      "policyUrl": "https://www.confiant.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 124,
+      "name": "Teemo SA",
+      "policyUrl": "https://teemo.co/fr/confidentialite/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 154,
+      "name": "YOC AG",
+      "policyUrl": "https://yoc.com/privacy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 38,
+      "name": "Beemray Oy",
+      "policyUrl": "https://www.beemray.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 101,
+      "name": "MiQ",
+      "policyUrl": "http://wearemiq.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 149,
+      "name": "ADman Interactive SL",
+      "policyUrl": "http://admanmedia.com/politica",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 151,
+      "name": "Admedo Ltd",
+      "policyUrl": "https://www.admedo.com/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 153,
+      "name": "MADVERTISE MEDIA",
+      "policyUrl": "http://madvertise.com/en/gdpr/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 159,
+      "name": "Underdog Media LLC ",
+      "policyUrl": "https://underdogmedia.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 157,
+      "name": "Seedtag Advertising S.L",
+      "policyUrl": "https://www.seedtag.com/en/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 145,
+      "name": "Snapsort Inc., operating as Sortable",
+      "policyUrl": "https://sortable.com/privacy",
+      "purposeIds": [
+        1,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 131,
+      "name": "ID5 Technology SAS",
+      "policyUrl": "https://www.id5.io/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 158,
+      "name": "Reveal Mobile, Inc",
+      "policyUrl": "revealmobile.com/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 147,
+      "name": "One Person Health, Inc. (DBA Adacado)",
+      "policyUrl": "https://www.adacado.com/privacy-policy-april-25-2018/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 130,
+      "name": "AdRoll Inc",
+      "policyUrl": "adrollgroup.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 129,
+      "name": "IPONWEB GmbH",
+      "policyUrl": "https://www.iponweb.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 128,
+      "name": "BIDSWITCH GmbH",
+      "policyUrl": "http://www.bidswitch.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 168,
+      "name": "EASYmedia GmbH",
+      "policyUrl": "https://login.rtbmarket.com/gdpr",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 164,
+      "name": "Outbrain UK Ltd",
+      "policyUrl": "https://www.outbrain.com/legal/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        4
+      ],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 144,
+      "name": "district m inc.",
+      "policyUrl": "https://districtm.net/en/page/platforms-data-and-privacy-policy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 163,
+      "name": "Bombora Inc.",
+      "policyUrl": "https://bombora.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 173,
+      "name": "Yieldmo, Inc.",
+      "policyUrl": "https://www.yieldmo.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 88,
+      "name": "TreSensa, Inc.",
+      "policyUrl": "www.tresensa.com/eu-privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 78,
+      "name": "Flashtalking, Inc.",
+      "policyUrl": "http://www.flashtalking.com/privacypolicy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 59,
+      "name": "Sift Media, Inc",
+      "policyUrl": "https://www.sift.co/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 114,
+      "name": "Sublime Skinz",
+      "policyUrl": "http://ayads.co/privacy.php",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 175,
+      "name": "FORTVISION",
+      "policyUrl": "http://fortvision.com/POC/index.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 133,
+      "name": "digitalAudience",
+      "policyUrl": "http://digitalaudience.io/legal/privacy-cookies/",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 14,
+      "name": "Adkernel LLC",
+      "policyUrl": "http://adkernel.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 180,
+      "name": "Thirdpresence Oy",
+      "policyUrl": "http://www.thirdpresence.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 183,
+      "name": "EMX Digital LLC",
+      "policyUrl": "https://emxdigital.com/privacy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 58,
+      "name": "33Across",
+      "policyUrl": "http://www.33across.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 140,
+      "name": "Platform161",
+      "policyUrl": "https://platform161.com/cookie-and-privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 90,
+      "name": "Teroa S.A.",
+      "policyUrl": "https://www.e-planning.net/en/privacy.html",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 141,
+      "name": "1020, Inc. dba Placecast and Ericsson Emodo",
+      "policyUrl": "https://www.ericsson-emodo.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 142,
+      "name": "Media.net Advertising FZ-LLC",
+      "policyUrl": "https://www.media.net/en/privacy-policy",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 209,
+      "name": "Delta Projects AB",
+      "policyUrl": "http://www.deltaprojects.com/data-collection-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 195,
+      "name": "advanced store GmbH",
+      "policyUrl": "http://www.advanced-store.com/de/datenschutz/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 197,
+      "name": "Switch Concepts Limited",
+      "policyUrl": "https://www.switchconcepts.com/privacy-policy",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 190,
+      "name": "video intelligence AG",
+      "policyUrl": "https://www.vi.ai/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 84,
+      "name": "Semasio GmbH",
+      "policyUrl": "http://www.semasio.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 65,
+      "name": "Location Sciences AI Ltd",
+      "policyUrl": "https://www.locationsciences.ai/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 210,
+      "name": "Zemanta, Inc.",
+      "policyUrl": "http://www.zemanta.com/legal/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 200,
+      "name": "Tapjoy, Inc.",
+      "policyUrl": "https://www.tapjoy.com/legal/#privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 188,
+      "name": "Sellpoints Inc.",
+      "policyUrl": "https://retargeter.com/service-privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 217,
+      "name": "2KDirect, Inc. (dba iPromote)",
+      "policyUrl": "https://www.ipromote.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 156,
+      "name": "Centro, Inc.",
+      "policyUrl": "https://www.centro.net/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 194,
+      "name": "Rezonence Limited",
+      "policyUrl": "https://rezonence.com/privacy-policy/",
+      "purposeIds": [
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 226,
+      "name": "Publicis Media GmbH",
+      "policyUrl": "https://www.publicismedia.de/datenschutz/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 198,
+      "name": "SYNC",
+      "policyUrl": "https://redirect.sync.tv/privacy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 227,
+      "name": "ORTEC B.V.",
+      "policyUrl": "https://www.ortecadscience.com/privacy-policy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 225,
+      "name": "Ligatus GmbH",
+      "policyUrl": "https://www.ligatus.com/en/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 205,
+      "name": "Adssets AB",
+      "policyUrl": "http://adssets.com/policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 179,
+      "name": "Collective Europe Ltd.",
+      "policyUrl": "https://www.timeincuk.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 31,
+      "name": "Ogury Ltd.",
+      "policyUrl": "https://www.ogury.com/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 92,
+      "name": "1plusX AG",
+      "policyUrl": "https://www.1plusx.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 155,
+      "name": "AntVoice",
+      "policyUrl": "https://www.antvoice.com/en/privacypolicy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 115,
+      "name": "smartclip Holding AG",
+      "policyUrl": "http://privacy-portal.smartclip.net/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 126,
+      "name": "DoubleVerify Inc.​",
+      "policyUrl": "https://www.doubleverify.com/privacy/",
+      "purposeIds": [
+        1,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 193,
+      "name": "Mediasmart Mobile S.L.",
+      "policyUrl": "http://mediasmart.io/privacy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 245,
+      "name": "IgnitionOne",
+      "policyUrl": "https://www.ignitionone.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 213,
+      "name": "emetriq GmbH",
+      "policyUrl": "https://www.emetriq.com/datenschutz/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 244,
+      "name": "Leadplace - Temelio",
+      "policyUrl": "https://temelio.com/vie-privee",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 224,
+      "name": "adrule GmbH",
+      "policyUrl": "https://www.adrule.net/de/datenschutz/",
+      "purposeIds": [
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 174,
+      "name": "A Million Ads Limited",
+      "policyUrl": "https://www.amillionads.com/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 192,
+      "name": "remerge GmbH",
+      "policyUrl": "https://remerge.io/privacy-policy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 232,
+      "name": "Rockerbox, Inc",
+      "policyUrl": "http://rockerbox.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 256,
+      "name": "Bounce Exchange, Inc",
+      "policyUrl": "https://www.bouncex.com/privacy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 234,
+      "name": "Zebestof",
+      "policyUrl": "http://www.zebestof.com/en/about-us-2/privacy-en/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 246,
+      "name": "Smartology Limited",
+      "policyUrl": "https://www.smartology.net/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 241,
+      "name": "OneTag Ltd",
+      "policyUrl": "https://www.onetag.net/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 254,
+      "name": "LiquidM Technology GmbH",
+      "policyUrl": "https://liquidm.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 215,
+      "name": "ARMIS SAS",
+      "policyUrl": "http://armis.tech/infos-cookies/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 167,
+      "name": "Audiens S.r.l.",
+      "policyUrl": "http://www.audiens.com/privacy",
+      "purposeIds": [
+        1,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 240,
+      "name": "7Hops.com Inc. (ZergNet)",
+      "policyUrl": "zergnet.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 235,
+      "name": "Bucksense Inc",
+      "policyUrl": "http://www.bucksense.com/platform-privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 185,
+      "name": "Bidtellect, Inc",
+      "policyUrl": "https://www.bidtellect.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 258,
+      "name": "Adello Group AG",
+      "policyUrl": "https://www.adello.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 169,
+      "name": "RTK.IO, Inc",
+      "policyUrl": "http://www.rtk.io/privacy.html",
+      "purposeIds": [
+        1,
+        4
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 208,
+      "name": "Spotad",
+      "policyUrl": "http://www.spotad.co/privacy-policy/",
+      "purposeIds": [
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 211,
+      "name": "AdTheorent, Inc",
+      "policyUrl": "http://adtheorent.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 229,
+      "name": "Digitize New Media Ltd",
+      "policyUrl": "http://www.digitize.ie/online-privacy",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 273,
+      "name": "Bannerflow AB",
+      "policyUrl": "bannerflow.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 104,
+      "name": "Sonobi, Inc",
+      "policyUrl": "http://sonobi.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 162,
+      "name": "Unruly Group Ltd",
+      "policyUrl": "https://unruly.co/privacy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 249,
+      "name": "Spolecznosci Sp. z o.o. Sp. k.",
+      "policyUrl": "https://www.spolecznosci.pl/polityka-prywatnosci",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 113,
+      "name": "iotec global Ltd.",
+      "policyUrl": "https://www.iotecglobal.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 125,
+      "name": "Research Now Group, Inc",
+      "policyUrl": "https://www.valuedopinions.co.uk/privacy",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 170,
+      "name": "Goodway Group, Inc.",
+      "policyUrl": "https://goodwaygroup.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 160,
+      "name": "Netsprint SA",
+      "policyUrl": "http://spoldzielnia.nsaudience.pl/opt-out/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 189,
+      "name": "Intowow Innovation Ltd.",
+      "policyUrl": "http://www.intowow.com/privacy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 279,
+      "name": "Mirando GmbH &amp; Co KG",
+      "policyUrl": "https://wwwmirando.de/datenschutz/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 269,
+      "name": "Sanoma Media Finland",
+      "policyUrl": "https://sanoma.fi/tietoa-meista/tietosuoja/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 276,
+      "name": "Viralize SRL",
+      "policyUrl": "https://viralize.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 87,
+      "name": "Genius Sports Media Limited",
+      "policyUrl": "http://www.geniussports.com/privacy-policy/",
+      "purposeIds": [
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 182,
+      "name": "Collective, Inc. dba Visto",
+      "policyUrl": "https://www.vistohub.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 255,
+      "name": "Onnetwork Sp. z o.o.",
+      "policyUrl": "https://www.onnetwork.tv/pp_services.php",
+      "purposeIds": [
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 203,
+      "name": "Revcontent, LLC",
+      "policyUrl": "https://faq.revcontent.com/customer/en/portal/articles/2703838-revcontent-s-privacy-and-cookie-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 260,
+      "name": "RockYou, Inc.",
+      "policyUrl": "https://rockyou.com/privacy-policy/",
+      "purposeIds": [
+        3
+      ],
+      "legIntPurposeIds": [
+        1,
+        2,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 237,
+      "name": "LKQD, a division of Nexstar Digital, LLC.",
+      "policyUrl": "http://www.lkqd.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 274,
+      "name": "Golden Bees",
+      "policyUrl": "http://goldenbees.fr/notre-politique-de-confidentialite/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 280,
+      "name": "Spot.IM Ltd.",
+      "policyUrl": "http://spot.im/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 239,
+      "name": "Triton Digital Canada Inc.",
+      "policyUrl": "https://www.tritondigital.com/privacy-policies",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 177,
+      "name": "plista GmbH",
+      "policyUrl": "https://www.plista.com/about/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 201,
+      "name": "TimeOne",
+      "policyUrl": "https://www.timeonegroup.com/en/privacy-policies/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 150,
+      "name": "Inskin Media LTD",
+      "policyUrl": "http://www.inskinmedia.com/privacy-policy.html",
+      "purposeIds": [
+        3
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 252,
+      "name": "Jaduda GmbH",
+      "policyUrl": "https://www.jadudamobile.com/datenschutzerklaerung/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 248,
+      "name": "Converge-Digital",
+      "policyUrl": "https://converge-digital.com/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 161,
+      "name": "Smadex SL",
+      "policyUrl": "http://smadex.com/end-user-privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 285,
+      "name": "Comcast International France SAS",
+      "policyUrl": "freewheel.tv/privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 228,
+      "name": "McCann Discipline LTD",
+      "policyUrl": "https://www.primis.tech/wp-content/uploads/2018/02/primisPrivacyPolicy2018.pdf",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 299,
+      "name": "AdClear GmbH",
+      "policyUrl": "https://www.adclear.de/datenschutzerklaerung/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 277,
+      "name": "Codewise Sp. z o.o. Sp. k",
+      "policyUrl": "https://voluumdsp.com/end-user-privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 259,
+      "name": "ADYOULIKE SA",
+      "policyUrl": "https://www.adyoulike.com/privacy_policy.php",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 289,
+      "name": "mobalo GmbH",
+      "policyUrl": "https://www.mobalo.com/datenschutz/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 272,
+      "name": "A.Mob",
+      "policyUrl": "https://adotmob.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 230,
+      "name": "Steel House, Inc.",
+      "policyUrl": "https://steelhouse.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 253,
+      "name": "Improve Digital International BV",
+      "policyUrl": "https://www.improvedigital.com/platform-privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 304,
+      "name": "On Device Research Limited",
+      "policyUrl": "https://s.on-device.com/privacyPolicy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 314,
+      "name": "Keymantics",
+      "policyUrl": "https://www.keymantics.com/assets/privacy-policy.pdf",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 257,
+      "name": "R-TARGET",
+      "policyUrl": "http://www.r-target.com/privacy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 317,
+      "name": "mainADV Srl",
+      "policyUrl": "http://www.mainad.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 278,
+      "name": "Integral Ad Science, Inc.",
+      "policyUrl": "https://integralads.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 291,
+      "name": "Qwertize",
+      "policyUrl": "https://www.qwertize.com/en/privacy",
+      "purposeIds": [
+        1,
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 295,
+      "name": "Sojern, Inc.",
+      "policyUrl": "https://www.sojern.com/privacy/product-privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 315,
+      "name": "Celtra, Inc.",
+      "policyUrl": "https://www.celtra.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 165,
+      "name": "SpotX",
+      "policyUrl": "https://www.spotx.tv/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 47,
+      "name": "ADMAN - Phaistos Networks, S.A.",
+      "policyUrl": "http://www.adman.gr/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 134,
+      "name": "SMARTSTREAM.TV GmbH",
+      "policyUrl": "https://www.smartstream.tv/en/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 325,
+      "name": "Knorex Pte Ltd",
+      "policyUrl": "https://www.knorex.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 316,
+      "name": "Gamned",
+      "policyUrl": "https://www.gamned.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 318,
+      "name": "Accorp Sp. z o.o.",
+      "policyUrl": "http://www.instytut-pollster.pl/privacy-policy/",
+      "purposeIds": [
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 199,
+      "name": "ADUX",
+      "policyUrl": "http://www.adux.com/donnees-personelles/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 236,
+      "name": "PowerLinks Media Limited",
+      "policyUrl": "https://www.powerlinks.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        5
+      ],
+      "legIntPurposeIds": [
+        3,
+        4
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 294,
+      "name": "Jivox Corp",
+      "policyUrl": "http://www.jivox.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 143,
+      "name": "Connatix Native Exchange Inc.",
+      "policyUrl": "https://connatix.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 297,
+      "name": "Polar Mobile Group Inc.",
+      "policyUrl": "https://privacy.polar.me",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 319,
+      "name": "Clipcentric, Inc.",
+      "policyUrl": "https://peter.clipcentric.com/privacy05252018.bhtml",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 290,
+      "name": "Readpeak Oy",
+      "policyUrl": "http://readpeak.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 323,
+      "name": "Perform Media Services Ltd",
+      "policyUrl": "http://www.performgroup.com/media-privacy-notice",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 119,
+      "name": "S4M",
+      "policyUrl": "http://www.s4m.io/privacy-policy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 302,
+      "name": "Mobile Professionals BV",
+      "policyUrl": "https://mobpro.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 212,
+      "name": "usemax advertisement (Emego GmbH)",
+      "policyUrl": "http://www.usemax.de/?l=privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 264,
+      "name": "Adobe Advertising Cloud",
+      "policyUrl": "https://www.adobe.com/nz/privacy/marketing-cloud.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 309,
+      "name": "Videology Ltd.",
+      "policyUrl": "https://videologygroup.com/en/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 44,
+      "name": "The ADEX GmbH",
+      "policyUrl": "www.theadex.com",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 282,
+      "name": "Welect GmbH",
+      "policyUrl": "https://www.welect.de/datenschutz",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 238,
+      "name": "StackAdapt",
+      "policyUrl": "www.stackadapt.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 284,
+      "name": "WEBORAMA",
+      "policyUrl": "https://weborama.com/privacy_en/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 148,
+      "name": "Liveintent Inc.",
+      "policyUrl": "https://liveintent.com/services-privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 64,
+      "name": "DigiTrust / IAB Tech Lab",
+      "policyUrl": "http://www.digitru.st/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 301,
+      "name": "zeotap GmbH",
+      "policyUrl": "https://www.zeotap.com/privacy_policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 275,
+      "name": "TabMo SAS",
+      "policyUrl": "http://static.tabmo.io.s3.amazonaws.com/privacy-policy/index.html",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 310,
+      "name": "Schibsted Classified Media Spain, S.L.",
+      "policyUrl": "https://www.vibbo.com/privacidad.htm?ca=0_s",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        4
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 139,
+      "name": "Permodo GmbH",
+      "policyUrl": "https://permodo.com/de/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 326,
+      "name": "AdTiming Technology Company Limited",
+      "policyUrl": "http://www.adtiming.com/en/privacypolicy.html",
+      "purposeIds": [
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        1,
+        2,
+        4
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 262,
+      "name": "Fyber ",
+      "policyUrl": "https://www.fyber.com/legal/privacy-policy/",
+      "purposeIds": [
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 331,
+      "name": "ad6media",
+      "policyUrl": "https://www.ad6media.fr/privacy",
+      "purposeIds": [
+        1,
+        2,
+        4
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 345,
+      "name": "The Kantar Group Limited",
+      "policyUrl": "http://www.kantar.com/cookies-policies",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 308,
+      "name": "Rockabox Media Ltd",
+      "policyUrl": "http://scoota.com/privacy-policy",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 270,
+      "name": "Marfeel Slutions S.L",
+      "policyUrl": "https://www.marfeel.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 333,
+      "name": "InMobi Pte Ltd",
+      "policyUrl": "https://www.inmobi.com/privacy-policy-for-eea",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 202,
+      "name": "Telaria, Inc",
+      "policyUrl": "https://telaria.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 328,
+      "name": "Gemius SA",
+      "policyUrl": "https://www.gemius.com/cookie-policy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 281,
+      "name": "Wizaly",
+      "policyUrl": "https://www.wizaly.com/terms-of-use#privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 354,
+      "name": "Apester Ltd",
+      "policyUrl": "https://apester.com/privacy-policy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 320,
+      "name": "Adelphic LLC",
+      "policyUrl": "https://adelphic.com/platform/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 359,
+      "name": "Aerserv LLC",
+      "policyUrl": "https://www.aerserv.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 265,
+      "name": "Instinctive, Inc.",
+      "policyUrl": "https://instinctive.io/privacy",
+      "purposeIds": [
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 349,
+      "name": "Optomaton UG",
+      "policyUrl": "http://optomaton.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 288,
+      "name": "Video Media Groep B.V.",
+      "policyUrl": "http://www.videomediagroup.com/wp-content/uploads/2016/01/Privacy-policy-VMG.pdf",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 266,
+      "name": "Digilant Spain, SLU",
+      "policyUrl": "https://www.digilant.com/es/politica-privacidad/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 339,
+      "name": "Vuble",
+      "policyUrl": "www.vuble.tv/us/privacy",
+      "purposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 303,
+      "name": "Orion Semantics",
+      "policyUrl": "http://static.orion-semantics.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 261,
+      "name": "Signal Digital Inc.",
+      "policyUrl": "https://www.signal.co/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 83,
+      "name": "Visarity Technologies GmbH",
+      "policyUrl": "http://primo.design/docs/PrivacyPolicyPrimo.html",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 343,
+      "name": "DIGITEKA Technologies",
+      "policyUrl": "https://www.ultimedia.com/default/presentation/cgu",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 330,
+      "name": "Linicom",
+      "policyUrl": "https://www.linicom.com/privacy/",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 231,
+      "name": "Acuityads Inc.",
+      "policyUrl": "https://www.acuityads.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 216,
+      "name": "Mindlytix SAS",
+      "policyUrl": "http://mindlytix.com/privacy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 360,
+      "name": "Permutive, Inc.",
+      "policyUrl": "https://permutive.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 361,
+      "name": "Onlysix Limited",
+      "policyUrl": "https://permutive.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 311,
+      "name": "Matomy Media Ltd.",
+      "policyUrl": "https://www.mobfox.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 358,
+      "name": "MGID Inc.",
+      "policyUrl": "https://www.mgid.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1
+      ]
+    },
+    {
+      "id": 152,
+      "name": "Meetrics GmbH",
+      "policyUrl": "https://www.meetrics.com/en/data-privacy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 251,
+      "name": "Yieldlove GmbH",
+      "policyUrl": "http://www.yieldlove.com/cookie-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 371,
+      "name": "Seeding Alliance GmbH",
+      "policyUrl": "http://seeding-alliance.de/datenschutz",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 344,
+      "name": "My6sense Inc.",
+      "policyUrl": "https://my6sense.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [
+        2,
+        4
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 347,
+      "name": "Ezoic Inc.",
+      "policyUrl": "https://www.ezoic.com/terms/",
+      "purposeIds": [
+        2,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 218,
+      "name": "Bigabid Media Ltd",
+      "policyUrl": "http://www.bigabid.com/data-protection/gdpr",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 350,
+      "name": "Free Stream Media Corp. dba Samba TV",
+      "policyUrl": "https://samba.tv/legal/privacy-policy-2-28-2018/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 351,
+      "name": "Samba TV UK Limited",
+      "policyUrl": "https://samba.tv/legal/privacy-policy-2-28-2018/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 341,
+      "name": "Somo Audience Corp",
+      "policyUrl": "https://somoaudience.com/legal/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 191,
+      "name": "realzeit GmbH",
+      "policyUrl": "https://realzeitmedia.com/privacy.html",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 380,
+      "name": "Vidoomy Media SL",
+      "policyUrl": "http://vidoomy.com/privacy-policy.html",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 378,
+      "name": "communicationAds GmbH &amp; Co. KG",
+      "policyUrl": "https://www.communicationads.net/aboutus/privacy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 369,
+      "name": "Getintent USA, inc.",
+      "policyUrl": "https://getintent.com/privacy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 184,
+      "name": "mediarithmics SAS",
+      "policyUrl": "http://www.mediarithmics.com/en/data-privacy.html",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 368,
+      "name": "VECTAURY",
+      "policyUrl": "https://www.vectaury.io/en/personal-data",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 373,
+      "name": "Nielsen Marketing Cloud",
+      "policyUrl": "http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 214,
+      "name": "Digital Control GmbH &amp; Co. KG",
+      "policyUrl": "http://advolution.de/privacy.php",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 388,
+      "name": "1000mercis",
+      "policyUrl": "http://ads.1000mercis.com/fr.html",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 250,
+      "name": "Qriously",
+      "policyUrl": "https://www.qriously.com/privacy",
+      "purposeIds": [
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 223,
+      "name": "Audience Trading Platform Ltd.",
+      "policyUrl": "https://atp.io/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 384,
+      "name": "Pixalate, Inc.",
+      "policyUrl": "http://pixalate.com/privacypolicy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 387,
+      "name": "Triapodi Ltd.",
+      "policyUrl": "https://appreciate.mobi/page.html#/end-user-privacy-policy",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 312,
+      "name": "Exactag GmbH",
+      "policyUrl": "https://www.exactag.com/en/data-privacy/",
+      "purposeIds": [
+        1,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 178,
+      "name": "Affectv Ltd",
+      "policyUrl": "https://affectv.com/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 377,
+      "name": "AddApptr GmbH",
+      "policyUrl": "https://www.addapptr.com/data-privacy",
+      "purposeIds": [
+        1,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 382,
+      "name": "The Reach Group GmbH",
+      "policyUrl": "https://www.reachgroup.com/en/privacy-statement/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 206,
+      "name": "Hybrid Adtech GmbH",
+      "policyUrl": "https://hybrid.ai/data_protection_policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 403,
+      "name": "Mobusi Mobile Advertising S.L.",
+      "policyUrl": "https://www.mobusi.com/privacy.en.html",
+      "purposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 385,
+      "name": "Oracle",
+      "policyUrl": "https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html, http://www.addthis.com/privacy/privacy-policy\r\n",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 404,
+      "name": "Duplo Media AS",
+      "policyUrl": "https://www.easy-ads.com/privacypolicy.htm",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 242,
+      "name": "twiago GmbH",
+      "policyUrl": "https://www.twiago.com/datenschutz/",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 376,
+      "name": "Pocketmath Pte Ltd",
+      "policyUrl": "www.pocketmath.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 402,
+      "name": "Effiliation",
+      "policyUrl": "https://inter.effiliation.com/politique-confidentialite.html",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 413,
+      "name": "Eulerian Technologies",
+      "policyUrl": "https://www.eulerian.com/en/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 391,
+      "name": "Seenergy Netherlands B.V.",
+      "policyUrl": "http://seenergy.com/privacy.html",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 400,
+      "name": "Whenever Media Ltd",
+      "policyUrl": "https://www.whenevermedia.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 171,
+      "name": "Webedia",
+      "policyUrl": "http://www.webedia-group.com/site/cookies",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 398,
+      "name": "Yormedia Solutions Ltd",
+      "policyUrl": "http://www.yormedia.com/privacy-and-cookies-notice/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 415,
+      "name": "Seenthis AB",
+      "policyUrl": "https://seenthis.co/privacy-notice-2018-04-18.pdf",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 263,
+      "name": "Nativo, Inc.",
+      "policyUrl": "https://www.nativo.com/interest-based-ads",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 329,
+      "name": "Browsi Mobile Ltd",
+      "policyUrl": "http://gobrowsi.com/browsi-privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 390,
+      "name": "Parsec Media Inc.",
+      "policyUrl": "www.parsec.media/privacy-policy",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 389,
+      "name": "Bidmanagement GmbH",
+      "policyUrl": "https://www.adspert.net/en/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 337,
+      "name": "SK Media Group, LLC",
+      "policyUrl": "http://www.sheknowsmedia.com/faq/ad-services-privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 422,
+      "name": "Brand Metrics Sweden AB",
+      "policyUrl": "https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 421,
+      "name": "LeftsnRight, Inc. dba LIQWID",
+      "policyUrl": "https://liqwid.solutions/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 426,
+      "name": "TradeTracker",
+      "policyUrl": "https://tradetracker.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 394,
+      "name": "AudienceProject Aps",
+      "policyUrl": "privacy.audienceproject.com",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 287,
+      "name": "Avazu Inc.",
+      "policyUrl": "http://avazuinc.com/opt-out/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 243,
+      "name": "Cloud Technologies S.A.",
+      "policyUrl": "http://onaudience.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 338,
+      "name": "dunnhumby Germany GmbH",
+      "policyUrl": "https://www.sociomantic.com/privacy/en/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 405,
+      "name": "IgnitionAi Ltd",
+      "policyUrl": "https://www.isitelab.io/default.aspx",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 416,
+      "name": "Commanders Act",
+      "policyUrl": "https://www.commandersact.com/en/privacy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 434,
+      "name": "DynAdmic",
+      "policyUrl": "http://eu.dynadmic.com/privacy-policy/",
+      "purposeIds": [
+        1,
+        3
+      ],
+      "legIntPurposeIds": [
+        2,
+        4
+      ],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 435,
+      "name": "SINGLESPOT SAS ",
+      "policyUrl": "https://www.singlespot.com/privacy_policy?locale=fr",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 409,
+      "name": "Arrivalist Co.",
+      "policyUrl": "https://www.arrivalist.com/privacy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 321,
+      "name": "Ziff Davis LLC",
+      "policyUrl": "http://www.ziffdavis.com/privacy-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 436,
+      "name": "INVIBES GROUP",
+      "policyUrl": "http://www.invibes.com/terms",
+      "purposeIds": [
+        2,
+        3,
+        4
+      ],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 442,
+      "name": "R-Advertising",
+      "policyUrl": "http://www.tradedoubler.com/en/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": []
+    },
+    {
+      "id": 362,
+      "name": "Myntelligence Limited",
+      "policyUrl": "http://www.myntelligence.com/privacy-page/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 418,
+      "name": "PROXISTORE",
+      "policyUrl": "https://www.proxistore.com/common/en/cgv",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        3
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 449,
+      "name": "Mobile Journey B.V.",
+      "policyUrl": "https://mobilejourney.com/Privacy-Policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 443,
+      "name": "Tradedoubler AB",
+      "policyUrl": "https://www.tradedoubler.com/en/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        5
+      ],
+      "featureIds": [
+        2
+      ]
+    },
+    {
+      "id": 429,
+      "name": "Signals",
+      "policyUrl": "http://signalsdata.com/platform-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 335,
+      "name": "Beachfront Media LLC",
+      "policyUrl": "http://beachfront.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 407,
+      "name": "Publishers Internationale Pty Ltd",
+      "policyUrl": "https://www.pi-rate.com.au/privacy.html",
+      "purposeIds": [
+        1,
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "id": 427,
+      "name": "Proxi.cloud Sp. z o.o.",
+      "policyUrl": "https://proxi.cloud/info/privacy-policy/",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 374,
+      "name": "Bmind a Sales Maker Company, S.L.",
+      "policyUrl": "http://www.bmind.es/legal-notice/",
+      "purposeIds": [
+        1,
+        2,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        2
+      ]
+    },
+    {
+      "id": 438,
+      "name": "Ooyala Inc",
+      "policyUrl": "ooyala.com/privacy",
+      "purposeIds": [
+        1,
+        2,
+        3
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        2,
+        3
+      ]
+    },
+    {
+      "id": 450,
+      "name": "Neodata Group srl",
+      "policyUrl": "https://www.neodatagroup.com/en/security-policy",
+      "purposeIds": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "legIntPurposeIds": [],
+      "featureIds": [
+        1,
+        3
+      ]
+    },
+    {
+      "id": 452,
+      "name": "Innovid Inc.",
+      "policyUrl": "http://www.innovid.com/privacy-policy",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        3,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 444,
+      "name": "Playbuzz Ltd. ",
+      "policyUrl": "https://www.playbuzz.com/PrivacyPolicy",
+      "purposeIds": [
+        2
+      ],
+      "legIntPurposeIds": [
+        1,
+        3,
+        4,
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 412,
+      "name": "Cxense ASA",
+      "policyUrl": "https://www.cxense.com/about-us/privacy-policy",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        2,
+        4,
+        5
+      ],
+      "featureIds": []
+    },
+    {
+      "id": 454,
+      "name": "Adimo",
+      "policyUrl": "https://adimo.co/privacy-policy/",
+      "purposeIds": [
+        1
+      ],
+      "legIntPurposeIds": [
+        5
+      ],
+      "featureIds": [
+        3
+      ]
+    },
+    {
+      "id": 293,
+      "name": "SpringServe, LLC",
+      "policyUrl": "https://springserve.com/privacy-policy/",
+      "purposeIds": [],
+      "legIntPurposeIds": [
+        1,
+        3
+      ],
+      "featureIds": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR:

* adds the GetVendorConsentsUseCase returning a VendorConsents as is specified in the IAB standard
* uses the IAB's consent-string library to decode the stored consent

![](https://media.giphy.com/media/iJzbNlFCtuWxW/giphy.gif)