### PR TITLE
Feature/global vendor list chained repository

### DIFF
--- a/src/cmp/infrastructure/cmpInitializer.js
+++ b/src/cmp/infrastructure/cmpInitializer.js
@@ -12,6 +12,8 @@ import SetVendorConsentsUseCase from '../application/SetVendorConsentsUseCase'
 import IABConsentManagementProviderV1 from './controller/IABConsentManagementProviderV1'
 import commandConsumer from './controller/commandConsumer'
 import Log from './Log'
+import ChainedVendorListRepository from './repository/ChainedVendorListRepository'
+import InMemoryVendorListRepository from './repository/InMemoryVendorListRepository'
 
 const initializeCMP = ({
   storeConsentGlobally = false,
@@ -37,8 +39,13 @@ const initializeCMP = ({
 
       const _consentFactory = consentFactory || new IABConsentFactory()
 
-      const _vendorListRepository =
+      const _remoteVendorListRepository =
         vendorListRepository || new HttpVendorListRepository()
+      const _inMemoryVendorListRepository = new InMemoryVendorListRepository()
+      const _vendorListRepository = new ChainedVendorListRepository({
+        inMemoryVendorListRepository: _inMemoryVendorListRepository,
+        httpVendorListRepository: _remoteVendorListRepository
+      })
 
       const _consentRepository =
         consentRepository ||

--- a/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
@@ -4,25 +4,39 @@
  */
 export default class ChainedVendorListRepository {
   constructor({inMemoryVendorListRepository, httpVendorListRepository} = {}) {
-    this._inMemoryVendorListRepository = inMemoryVendorListRepository
-    this._httpVendorListRepository = httpVendorListRepository
+    this._getLocalVendorList = getLocalVendorList({
+      inMemoryVendorListRepository
+    })
+    this._getRemoteVendorList = getRemoteVendorList({httpVendorListRepository})
+    this._saveRemoteVendorListToLocal = saveRemoteVendorListToLocal({
+      inMemoryVendorListRepository
+    })
   }
 
   getGlobalVendorList() {
     return Promise.resolve()
-      .then(() => this._inMemoryVendorListRepository.getGlobalVendorList())
+      .then(this._getLocalVendorList)
       .then(
         globalVendorList =>
           globalVendorList ||
-          this._httpVendorListRepository
-            .getGlobalVendorList()
-            .then(globalVendorList =>
-              this._inMemoryVendorListRepository
-                .setGlobalVendorList({
-                  globalVendorList
-                })
-                .then(() => globalVendorList)
+          this._getRemoteVendorList().then(globalVendorList =>
+            this._saveRemoteVendorListToLocal({globalVendorList}).then(
+              () => globalVendorList
             )
+          )
       )
   }
 }
+
+const getLocalVendorList = ({inMemoryVendorListRepository}) => () =>
+  inMemoryVendorListRepository.getGlobalVendorList()
+
+const getRemoteVendorList = ({httpVendorListRepository}) => () =>
+  httpVendorListRepository.getGlobalVendorList()
+
+const saveRemoteVendorListToLocal = ({inMemoryVendorListRepository}) => ({
+  globalVendorList
+}) =>
+  inMemoryVendorListRepository.setGlobalVendorList({
+    globalVendorList
+  })

--- a/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
@@ -1,0 +1,28 @@
+/**
+ * @class
+ * @implements VendorListRepository
+ */
+export default class ChainedVendorListRepository {
+  constructor({inMemoryVendorListRepository, httpVendorListRepository} = {}) {
+    this._inMemoryVendorListRepository = inMemoryVendorListRepository
+    this._httpVendorListRepository = httpVendorListRepository
+  }
+
+  getGlobalVendorList() {
+    return Promise.resolve()
+      .then(() => this._inMemoryVendorListRepository.getGlobalVendorList())
+      .then(
+        globalVendorList =>
+          globalVendorList ||
+          this._httpVendorListRepository
+            .getGlobalVendorList()
+            .then(globalVendorList =>
+              this._inMemoryVendorListRepository
+                .setGlobalVendorList({
+                  globalVendorList
+                })
+                .then(() => globalVendorList)
+            )
+      )
+  }
+}

--- a/src/cmp/infrastructure/repository/InMemoryVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/InMemoryVendorListRepository.js
@@ -1,0 +1,19 @@
+/**
+ * @class
+ * @implements VendorListRepository
+ */
+export default class InMemoryVendorListRepository {
+  constructor({globalVendorList} = {}) {
+    this._globalVendorList = globalVendorList
+  }
+
+  getGlobalVendorList() {
+    return Promise.resolve(this._globalVendorList)
+  }
+
+  setGlobalVendorList({globalVendorList}) {
+    return Promise.resolve()
+      .then(() => (this._globalVendorList = globalVendorList))
+      .then(() => this._globalVendorList)
+  }
+}

--- a/src/cmp/infrastructure/repository/InMemoryVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/InMemoryVendorListRepository.js
@@ -12,8 +12,8 @@ export default class InMemoryVendorListRepository {
   }
 
   setGlobalVendorList({globalVendorList}) {
-    return Promise.resolve()
-      .then(() => (this._globalVendorList = globalVendorList))
-      .then(() => this._globalVendorList)
+    return Promise.resolve().then(
+      () => (this._globalVendorList = globalVendorList)
+    )
   }
 }

--- a/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai'
 import sinon from 'sinon'
-import HttpVendorListRepository from '../../../../src/cmp/infrastructure/repository/HttpVendorListRepository'
 import ChainedVendorListRepository from '../../../../src/cmp/infrastructure/repository/ChainedVendorListRepository'
 
 describe('ChainedVendorListRepository', () => {

--- a/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
@@ -1,0 +1,86 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import HttpVendorListRepository from '../../../../src/cmp/infrastructure/repository/HttpVendorListRepository'
+import ChainedVendorListRepository from '../../../../src/cmp/infrastructure/repository/ChainedVendorListRepository'
+
+describe('ChainedVendorListRepository', () => {
+  describe('getGlobalVendorList', () => {
+    it('Should return the inmemory vendor list if it is found', done => {
+      const expectedResult = {inmemory: 'vendorlist'}
+      const inMemoryVendorListRepositoryMock = {
+        getGlobalVendorList: () => Promise.resolve(expectedResult)
+      }
+      const httpVendorListRepositoryMock = {
+        getGlobalVendorList: () => Promise.resolve({http: 'vendorlist'})
+      }
+      const httpGetGlobalVendorListSpy = sinon.spy(
+        httpVendorListRepositoryMock,
+        'getGlobalVendorList'
+      )
+
+      const repository = new ChainedVendorListRepository({
+        inMemoryVendorListRepository: inMemoryVendorListRepositoryMock,
+        httpVendorListRepository: httpVendorListRepositoryMock
+      })
+      repository
+        .getGlobalVendorList()
+        .then(result => {
+          expect(
+            httpGetGlobalVendorListSpy.called,
+            'should have not called the http repository'
+          ).to.be.false
+          expect(
+            result,
+            'the resulting vendor list should be the inmemory vendor list'
+          ).to.deep.equal(expectedResult)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should return the http vendor list if it is not found into the inmemory repository, and set it inmemory for next calls', done => {
+      const expectedResult = {http: 'vendorlist'}
+      const inMemoryVendorListRepositoryMock = {
+        getGlobalVendorList: () => Promise.resolve(undefined),
+        setGlobalVendorList: () => Promise.resolve()
+      }
+      const httpVendorListRepositoryMock = {
+        getGlobalVendorList: () => Promise.resolve(expectedResult)
+      }
+      const inMemorySetGlobalVendorListSpy = sinon.spy(
+        inMemoryVendorListRepositoryMock,
+        'setGlobalVendorList'
+      )
+      const inMemoryGetGlobalVendorListSpy = sinon.spy(
+        inMemoryVendorListRepositoryMock,
+        'getGlobalVendorList'
+      )
+
+      const repository = new ChainedVendorListRepository({
+        inMemoryVendorListRepository: inMemoryVendorListRepositoryMock,
+        httpVendorListRepository: httpVendorListRepositoryMock
+      })
+      repository
+        .getGlobalVendorList()
+        .then(result => {
+          expect(
+            inMemoryGetGlobalVendorListSpy.calledOnce,
+            'should have called the inmemory repository -get- to try to get the vendor list from there first'
+          ).to.be.true
+          expect(
+            result,
+            'the resulting vendor list should be the http vendor list'
+          ).to.deep.equal(expectedResult)
+          expect(
+            inMemorySetGlobalVendorListSpy.calledOnce,
+            'should have called the set method of the inmemory repository'
+          ).to.be.true
+          expect(
+            inMemorySetGlobalVendorListSpy.args[0][0].globalVendorList,
+            'should store the http vendor list to the inmemory repository'
+          ).to.deep.equal(expectedResult)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+  })
+})

--- a/test/cmp/infrastructure/repository/InMemoryVendorListRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/InMemoryVendorListRepositoryTest.js
@@ -1,0 +1,55 @@
+import {expect} from 'chai'
+import InMemoryVendorListRepository from '../../../../src/cmp/infrastructure/repository/InMemoryVendorListRepository'
+
+describe('InMemoryVendorListRepository', () => {
+  describe('getGlobalVendorList', () => {
+    it('Should return undefined if no globalVendorList is set', done => {
+      const repository = new InMemoryVendorListRepository()
+
+      repository
+        .getGlobalVendorList()
+        .then(result => {
+          expect(result, 'the global vendor list should be undefined').to.be
+            .undefined
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should return the stored globalVendorList if is set', done => {
+      const givenGlobalVendorList = {what: 'ever'}
+      const repository = new InMemoryVendorListRepository({
+        globalVendorList: givenGlobalVendorList
+      })
+
+      repository
+        .getGlobalVendorList()
+        .then(result => {
+          expect(
+            result,
+            'the global vendor list should be the given vendor list'
+          ).to.deep.equal(givenGlobalVendorList)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should update the stored global vendor list', done => {
+      const givenInitialGlobalVendorList = {what: 'ever'}
+      const givenUpdatedGlobalVendorList = {what: 'ever', up: 'dated'}
+      const repository = new InMemoryVendorListRepository({
+        globalVendorList: givenInitialGlobalVendorList
+      })
+
+      repository
+        .setGlobalVendorList({globalVendorList: givenUpdatedGlobalVendorList})
+        .then(() => repository.getGlobalVendorList())
+        .then(result => {
+          expect(
+            result,
+            'the global vendor list should be the updated vendor list'
+          ).to.deep.equal(givenUpdatedGlobalVendorList)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+  })
+})

--- a/test/cmp/infrastructure/repository/InMemoryVendorListRepositoryTest.js
+++ b/test/cmp/infrastructure/repository/InMemoryVendorListRepositoryTest.js
@@ -32,6 +32,8 @@ describe('InMemoryVendorListRepository', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+  })
+  describe('setGlobalVendorList', () => {
     it('Should update the stored global vendor list', done => {
       const givenInitialGlobalVendorList = {what: 'ever'}
       const givenUpdatedGlobalVendorList = {what: 'ever', up: 'dated'}


### PR DESCRIPTION
This PR:

* Add an InMemoryVendorListRepository capable of store in memory a VendorList object
* Add a ChainedVendorListRepository that orchestates a caching system to get the remote (http) global vendor list in the first call and stores it to the in memory repository to retireve the vendor list locally on consecutive calls

![](https://media.giphy.com/media/XaNNjSrv1wHXq/giphy.gif)