### PR TITLE
Add the observer callbacks in the controller

### DIFF
--- a/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
+++ b/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
@@ -15,45 +15,27 @@ export default class IABConsentManagementProviderV1 {
     this._setVendorConsentsUseCase = setVendorConsentsUseCase
   }
 
-  getVendorConsents(vendorIds, observer) {
-    return this._getVendorConsentsUseCase
-      .getVendorConsents({vendorIds})
-      .then(vendorConsents => observer(vendorConsents, true))
-      .catch(e => observer(null, false))
+  getVendorConsents(vendorIds) {
+    return this._getVendorConsentsUseCase.getVendorConsents({vendorIds})
   }
 
-  setVendorConsents(vendorConsents, observer) {
-    return this._setVendorConsentsUseCase
-      .setVendorConsents({vendorConsents})
-      .then(() => observer(null, true))
-      .catch(e => observer(null, false))
+  setVendorConsents(vendorConsents) {
+    return this._setVendorConsentsUseCase.setVendorConsents({vendorConsents})
   }
 
-  getConsentData(consentStringVersion, observer) {
-    return this._getConsentDataUseCase
-      .getConsentData({consentStringVersion})
-      .then(vendorConsentData => observer(vendorConsentData, true))
-      .catch(e => observer(null, false))
+  getConsentData(consentStringVersion) {
+    return this._getConsentDataUseCase.getConsentData({consentStringVersion})
   }
 
-  ping(_, observer) {
-    return this._pingUseCase
-      .ping()
-      .then(pingReturn => observer(pingReturn, true))
-      .catch(e => observer(null, false))
+  ping(_) {
+    return this._pingUseCase.ping()
   }
 
-  getVendorList(vendorListVersion, observer) {
-    return this._getVendorListUseCase
-      .getVendorList({vendorListVersion})
-      .then(globalVendorList => observer(globalVendorList, true))
-      .catch(e => observer(null, false))
+  getVendorList(vendorListVersion) {
+    return this._getVendorListUseCase.getVendorList({vendorListVersion})
   }
 
-  getConsentStatus(_, observer) {
-    return this._getConsentStatusUseCase
-      .getConsentStatus()
-      .then(consentStatus => observer(consentStatus, true))
-      .catch(e => observer(null, false))
+  getConsentStatus(_) {
+    return this._getConsentStatusUseCase.getConsentStatus()
   }
 }

--- a/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
+++ b/src/cmp/infrastructure/controller/IABConsentManagementProviderV1.js
@@ -1,6 +1,3 @@
-import InvalidVendorListVersionError from '../../domain/InvalidVendorListVersionError'
-import UnexistingConsentDataError from '../../domain/UnexistingConsentDataError'
-
 export default class IABConsentManagementProviderV1 {
   constructor({
     getVendorConsentsUseCase,
@@ -22,47 +19,41 @@ export default class IABConsentManagementProviderV1 {
     return this._getVendorConsentsUseCase
       .getVendorConsents({vendorIds})
       .then(vendorConsents => observer(vendorConsents, true))
-      .catch(
-        e =>
-          e instanceof UnexistingConsentDataError
-            ? observer(null, false)
-            : Promise.reject(e)
-      )
+      .catch(e => observer(null, false))
   }
 
   setVendorConsents(vendorConsents, observer) {
     return this._setVendorConsentsUseCase
       .setVendorConsents({vendorConsents})
       .then(() => observer(null, true))
+      .catch(e => observer(null, false))
   }
 
   getConsentData(consentStringVersion, observer) {
     return this._getConsentDataUseCase
       .getConsentData({consentStringVersion})
       .then(vendorConsentData => observer(vendorConsentData, true))
+      .catch(e => observer(null, false))
   }
 
   ping(_, observer) {
     return this._pingUseCase
       .ping()
       .then(pingReturn => observer(pingReturn, true))
+      .catch(e => observer(null, false))
   }
 
   getVendorList(vendorListVersion, observer) {
     return this._getVendorListUseCase
       .getVendorList({vendorListVersion})
       .then(globalVendorList => observer(globalVendorList, true))
-      .catch(
-        e =>
-          e instanceof InvalidVendorListVersionError
-            ? observer(null, false)
-            : Promise.reject(e)
-      )
+      .catch(e => observer(null, false))
   }
 
   getConsentStatus(_, observer) {
     return this._getConsentStatusUseCase
       .getConsentStatus()
       .then(consentStatus => observer(consentStatus, true))
+      .catch(e => observer(null, false))
   }
 }

--- a/src/cmp/infrastructure/controller/commandConsumer.js
+++ b/src/cmp/infrastructure/controller/commandConsumer.js
@@ -1,19 +1,24 @@
 const commandConsumer = log => controller => (
   command,
   parameters,
-  observer
+  observer = () => null
 ) => {
   return Promise.resolve()
     .then(() => log.debug('Received command:', command))
-    .then(() => {
-      if (command && typeof controller[command] === 'function') {
-        return Promise.resolve(controller[command](parameters, observer)).then(
-          null
-        )
-      } else {
-        return Promise.reject(new Error('Unexisting command: ' + command))
-      }
+    .then(() => filterCommandIsFunction({controller, command}))
+    .then(validCommand => controller[validCommand](parameters, observer))
+    .then(() => true)
+    .catch(e => {
+      log.error('Error executing command:', command, '-', e.message)
+      return false
     })
-    .catch(e => log.error('Error executing command:', command, '-', e.message))
 }
 export default commandConsumer
+
+const filterCommandIsFunction = ({controller, command}) => {
+  if (command && typeof controller[command] === 'function') {
+    return Promise.resolve(command)
+  } else {
+    return Promise.reject(new Error('Unexisting command: ' + command))
+  }
+}

--- a/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
+++ b/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
@@ -4,7 +4,7 @@ import IABConsentManagementProviderV1 from '../../../../src/cmp/infrastructure/c
 
 describe('IAB Consent Management Provider V1', () => {
   describe('getVendorConsents method', () => {
-    it('Should call get vendor consents use case and call the observer with success value', done => {
+    it('Should call get vendor consents use case', done => {
       const givenVendorIds = [1, 2]
       const expectedResult = 'expected result'
       const getVendorConsentsUseCaseMock = {
@@ -14,13 +14,12 @@ describe('IAB Consent Management Provider V1', () => {
         getVendorConsentsUseCaseMock,
         'getVendorConsents'
       )
-      const observerSpy = sinon.spy()
 
       const iabCMP = new IABConsentManagementProviderV1({
         getVendorConsentsUseCase: getVendorConsentsUseCaseMock
       })
       iabCMP
-        .getVendorConsents(givenVendorIds, observerSpy)
+        .getVendorConsents(givenVendorIds)
         .then(() => {
           expect(
             getVendorConsentsSpy.calledOnce,
@@ -30,40 +29,14 @@ describe('IAB Consent Management Provider V1', () => {
             getVendorConsentsSpy.args[0][0],
             'get vendor consents should have received only the business parameters'
           ).to.deep.equals({vendorIds: givenVendorIds})
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
-          expect(observerSpy.args[0][1]).to.be.true
-        })
-        .then(() => done())
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const getVendorConsentsUseCaseMock = {
-        getVendorConsents: () =>
-          Promise.reject(new Error('It is an error for the test'))
-      }
-      const observerSpy = sinon.spy()
-
-      const iabCMP = new IABConsentManagementProviderV1({
-        getVendorConsentsUseCase: getVendorConsentsUseCaseMock
-      })
-      iabCMP
-        .getVendorConsents(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))
     })
   })
+
   describe('getConsentData method', () => {
-    it('Should call get consent data use case and call the observer with success value', done => {
+    it('Should call get consent data use case', done => {
       const givenConsentStringVersion = 'whatever'
       const expectedResult = 'expected result'
       const getConsentDataUseCaseMock = {
@@ -73,13 +46,12 @@ describe('IAB Consent Management Provider V1', () => {
         getConsentDataUseCaseMock,
         'getConsentData'
       )
-      const observerSpy = sinon.spy()
 
       const iabCMP = new IABConsentManagementProviderV1({
         getConsentDataUseCase: getConsentDataUseCaseMock
       })
       iabCMP
-        .getConsentData(givenConsentStringVersion, observerSpy)
+        .getConsentData(givenConsentStringVersion)
         .then(() => {
           expect(
             getConsentDataSpy.calledOnce,
@@ -89,33 +61,6 @@ describe('IAB Consent Management Provider V1', () => {
             getConsentDataSpy.args[0][0],
             'get consent data should have received only the business parameters'
           ).to.deep.equals({consentStringVersion: givenConsentStringVersion})
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
-          expect(observerSpy.args[0][1]).to.be.true
-        })
-        .then(() => done())
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const getConsentDataUseCaseMock = {
-        getConsentData: () =>
-          Promise.reject(new Error('It is an error for the test'))
-      }
-      const observerSpy = sinon.spy()
-
-      const iabCMP = new IABConsentManagementProviderV1({
-        getConsentDataUseCase: getConsentDataUseCaseMock
-      })
-      iabCMP
-        .getConsentData(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))
@@ -131,43 +76,14 @@ describe('IAB Consent Management Provider V1', () => {
       const iabCMP = new IABConsentManagementProviderV1({
         getConsentStatusUseCase: consentStatusUseCaseMock
       })
-      const observerSpy = sinon.spy()
       iabCMP
-        .getConsentStatus(null, observerSpy)
-        .then(result => {
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
-          expect(observerSpy.args[0][1]).to.be.true
-          done()
-        })
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const consentStatusUseCaseMock = {
-        getConsentStatus: () =>
-          Promise.reject(new Error('It is an error for the test'))
-      }
-      const iabCMP = new IABConsentManagementProviderV1({
-        getConsentStatusUseCase: consentStatusUseCaseMock
-      })
-      const observerSpy = sinon.spy()
-      iabCMP
-        .getConsentStatus(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
-        })
+        .getConsentStatus(null)
         .then(() => done())
         .catch(e => done(e))
     })
   })
   describe('getVendorList method', () => {
-    it('Should call get vendor list use case and call the observer with success value', done => {
+    it('Should call get vendor list use case', done => {
       const givenVendorListVersion = 999
       const expectedResult = 'expected result'
       const getVendorListUseCaseMock = {
@@ -177,13 +93,12 @@ describe('IAB Consent Management Provider V1', () => {
         getVendorListUseCaseMock,
         'getVendorList'
       )
-      const observerSpy = sinon.spy()
 
       const iabCMP = new IABConsentManagementProviderV1({
         getVendorListUseCase: getVendorListUseCaseMock
       })
       iabCMP
-        .getVendorList(givenVendorListVersion, observerSpy)
+        .getVendorList(givenVendorListVersion)
         .then(() => {
           expect(
             getVendorListSpy.calledOnce,
@@ -193,33 +108,6 @@ describe('IAB Consent Management Provider V1', () => {
             getVendorListSpy.args[0][0],
             'get vendor list should have received only the business parameters'
           ).to.deep.equals({vendorListVersion: givenVendorListVersion})
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
-          expect(observerSpy.args[0][1]).to.be.true
-        })
-        .then(() => done())
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const getVendorListUseCaseMock = {
-        getVendorList: () =>
-          Promise.reject(new Error('It is an error for the test'))
-      }
-      const observerSpy = sinon.spy()
-
-      const iabCMP = new IABConsentManagementProviderV1({
-        getVendorListUseCase: getVendorListUseCaseMock
-      })
-      iabCMP
-        .getVendorList(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))
@@ -232,41 +120,14 @@ describe('IAB Consent Management Provider V1', () => {
         ping: () => Promise.resolve().then(() => expectedResult)
       }
       const pingSpy = sinon.spy(pingUseCaseMock, 'ping')
-      const observerSpy = sinon.spy()
 
       const iabCMP = new IABConsentManagementProviderV1({
         pingUseCase: pingUseCaseMock
       })
       iabCMP
-        .ping(null, observerSpy)
+        .ping(null)
         .then(() => {
           expect(pingSpy.calledOnce, 'ping shoud have been called').to.be.true
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
-          expect(observerSpy.args[0][1]).to.be.true
-        })
-        .then(() => done())
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const pingUseCaseMock = {
-        ping: () => Promise.reject(new Error('It is an error for the test'))
-      }
-      const observerSpy = sinon.spy()
-
-      const iabCMP = new IABConsentManagementProviderV1({
-        pingUseCase: pingUseCaseMock
-      })
-      iabCMP
-        .ping(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))
@@ -285,13 +146,12 @@ describe('IAB Consent Management Provider V1', () => {
         setVendorConsentsUseCaseMock,
         'setVendorConsents'
       )
-      const observerSpy = sinon.spy()
 
       const iabCMP = new IABConsentManagementProviderV1({
         setVendorConsentsUseCase: setVendorConsentsUseCaseMock
       })
       iabCMP
-        .setVendorConsents(givenVendorConsents, observerSpy)
+        .setVendorConsents(givenVendorConsents)
         .then(() => {
           expect(
             setVendorConsentsSpy.calledOnce,
@@ -301,32 +161,6 @@ describe('IAB Consent Management Provider V1', () => {
             setVendorConsentsSpy.args[0][0],
             'set vendor consents should have received only the business parameters'
           ).to.deep.equals({vendorConsents: givenVendorConsents})
-          expect(observerSpy.calledOnce, 'observer should have been called').to
-            .be.true
-          expect(observerSpy.args[0][1]).to.be.true
-        })
-        .then(() => done())
-        .catch(e => done(e))
-    })
-    it('Should call the callback with false success if any error is thrown', done => {
-      const setVendorConsentsUseCaseMock = {
-        setVendorConsents: () =>
-          Promise.reject(new Error('It is an error for the test'))
-      }
-      const observerSpy = sinon.spy()
-
-      const iabCMP = new IABConsentManagementProviderV1({
-        setVendorConsentsUseCase: setVendorConsentsUseCaseMock
-      })
-      iabCMP
-        .setVendorConsents(null, observerSpy)
-        .then(() => {
-          expect(observerSpy.calledOnce, 'the observer shoud have been called')
-            .to.be.true
-          expect(
-            observerSpy.args[0][1],
-            'the success parameter should be false'
-          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
+++ b/test/cmp/infrastructure/controller/IABConsentManagementProviderV1Test.js
@@ -38,6 +38,29 @@ describe('IAB Consent Management Provider V1', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const getVendorConsentsUseCaseMock = {
+        getVendorConsents: () =>
+          Promise.reject(new Error('It is an error for the test'))
+      }
+      const observerSpy = sinon.spy()
+
+      const iabCMP = new IABConsentManagementProviderV1({
+        getVendorConsentsUseCase: getVendorConsentsUseCaseMock
+      })
+      iabCMP
+        .getVendorConsents(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
   describe('getConsentData method', () => {
     it('Should call get consent data use case and call the observer with success value', done => {
@@ -74,6 +97,29 @@ describe('IAB Consent Management Provider V1', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const getConsentDataUseCaseMock = {
+        getConsentData: () =>
+          Promise.reject(new Error('It is an error for the test'))
+      }
+      const observerSpy = sinon.spy()
+
+      const iabCMP = new IABConsentManagementProviderV1({
+        getConsentDataUseCase: getConsentDataUseCaseMock
+      })
+      iabCMP
+        .getConsentData(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
 
   describe('getConsentStatus method', () => {
@@ -95,6 +141,28 @@ describe('IAB Consent Management Provider V1', () => {
           expect(observerSpy.args[0][1]).to.be.true
           done()
         })
+        .catch(e => done(e))
+    })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const consentStatusUseCaseMock = {
+        getConsentStatus: () =>
+          Promise.reject(new Error('It is an error for the test'))
+      }
+      const iabCMP = new IABConsentManagementProviderV1({
+        getConsentStatusUseCase: consentStatusUseCaseMock
+      })
+      const observerSpy = sinon.spy()
+      iabCMP
+        .getConsentStatus(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
+        })
+        .then(() => done())
         .catch(e => done(e))
     })
   })
@@ -133,6 +201,29 @@ describe('IAB Consent Management Provider V1', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const getVendorListUseCaseMock = {
+        getVendorList: () =>
+          Promise.reject(new Error('It is an error for the test'))
+      }
+      const observerSpy = sinon.spy()
+
+      const iabCMP = new IABConsentManagementProviderV1({
+        getVendorListUseCase: getVendorListUseCaseMock
+      })
+      iabCMP
+        .getVendorList(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
   describe('ping method', () => {
     it('Should call the ping use case and call the observer with success value', done => {
@@ -154,6 +245,28 @@ describe('IAB Consent Management Provider V1', () => {
             .be.true
           expect(observerSpy.args[0][0]).to.deep.equals(expectedResult)
           expect(observerSpy.args[0][1]).to.be.true
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const pingUseCaseMock = {
+        ping: () => Promise.reject(new Error('It is an error for the test'))
+      }
+      const observerSpy = sinon.spy()
+
+      const iabCMP = new IABConsentManagementProviderV1({
+        pingUseCase: pingUseCaseMock
+      })
+      iabCMP
+        .ping(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))
@@ -191,6 +304,29 @@ describe('IAB Consent Management Provider V1', () => {
           expect(observerSpy.calledOnce, 'observer should have been called').to
             .be.true
           expect(observerSpy.args[0][1]).to.be.true
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('Should call the callback with false success if any error is thrown', done => {
+      const setVendorConsentsUseCaseMock = {
+        setVendorConsents: () =>
+          Promise.reject(new Error('It is an error for the test'))
+      }
+      const observerSpy = sinon.spy()
+
+      const iabCMP = new IABConsentManagementProviderV1({
+        setVendorConsentsUseCase: setVendorConsentsUseCaseMock
+      })
+      iabCMP
+        .setVendorConsents(null, observerSpy)
+        .then(() => {
+          expect(observerSpy.calledOnce, 'the observer shoud have been called')
+            .to.be.true
+          expect(
+            observerSpy.args[0][1],
+            'the success parameter should be false'
+          ).to.be.false
         })
         .then(() => done())
         .catch(e => done(e))

--- a/test/cmp/infrastructure/controller/commandConsumerTest.js
+++ b/test/cmp/infrastructure/controller/commandConsumerTest.js
@@ -8,45 +8,37 @@ describe('commandConsumer', () => {
     error: () => null
   })
   describe('Given an executable command', () => {
-    it('Should call the valid CMP controller command without errors', done => {
+    it('Should call the valid CMP controller command without errors and call the observer with success value and result value', done => {
       const logMock = createLogMock()
+      const expectedResultValue = 'result value'
       const controllerMock = {
-        anyIABmethod: () => Promise.resolve()
+        anyIABmethod: () => Promise.resolve(expectedResultValue)
       }
       const methodSpy = sinon.spy(controllerMock, 'anyIABmethod')
       const parameters = {
         key: 'value'
       }
-      const observer = () => null
       const __cmp = commandConsumer(logMock)(controllerMock)
 
-      __cmp('anyIABmethod', parameters, observer)
-        .then(
-          result =>
+      const observer = (result, success) => {
+        Promise.resolve()
+          .then(() => {
             expect(
               result,
-              'output value should be true when no errors are found'
-            ).to.be.true
-        )
-        .then(
-          () =>
+              'received result should be the expected result'
+            ).to.equal(result)
+            expect(success, 'success value should be true').to.be.true
             expect(methodSpy.calledOnce, 'CMP method shoud be called').to.be
               .true
-        )
-        .then(() =>
-          expect(
-            methodSpy.args[0][0],
-            'CMP call should recieve the parameters'
-          ).to.deep.equals(parameters)
-        )
-        .then(() =>
-          expect(
-            methodSpy.args[0][1],
-            'CMP call should recieve the callback'
-          ).to.equals(observer)
-        )
-        .then(() => done())
-        .catch(e => done(e))
+            expect(
+              methodSpy.args[0][0],
+              'CMP call should recieve the parameters'
+            ).to.deep.equals(parameters)
+            done()
+          })
+          .catch(e => done(e))
+      }
+      __cmp('anyIABmethod', parameters, observer).catch(e => done(e))
     })
   })
   describe('Given an inexisting command', () => {
@@ -57,22 +49,16 @@ describe('commandConsumer', () => {
       const observer = () => 'whatever'
       const logErrorSpy = sinon.spy(logMock, 'error')
       commandConsumer(logMock)(controllerMock)('whatever', parameters, observer)
-        .then(
-          result =>
-            expect(result, 'output value should be false when an error occurs')
-              .to.be.false
-        )
-        .then(
-          () =>
-            expect(logErrorSpy.calledOnce, 'Should have logged the error').to.be
-              .true
-        )
-        .then(() =>
+        .then(result => {
+          expect(result, 'output value should be false when an error occurs').to
+            .be.false
+          expect(logErrorSpy.calledOnce, 'Should have logged the error').to.be
+            .true
           expect(
             logErrorSpy.args[0].join(),
             'The error should indicate that the command does not exist'
           ).to.include('Unexisting command')
-        )
+        })
         .then(() => done())
         .catch(e => done(e))
     })

--- a/test/cmp/infrastructure/controller/commandConsumerTest.js
+++ b/test/cmp/infrastructure/controller/commandConsumerTest.js
@@ -22,6 +22,13 @@ describe('commandConsumer', () => {
 
       __cmp('anyIABmethod', parameters, observer)
         .then(
+          result =>
+            expect(
+              result,
+              'output value should be true when no errors are found'
+            ).to.be.true
+        )
+        .then(
           () =>
             expect(methodSpy.calledOnce, 'CMP method shoud be called').to.be
               .true
@@ -51,6 +58,11 @@ describe('commandConsumer', () => {
       const logErrorSpy = sinon.spy(logMock, 'error')
       commandConsumer(logMock)(controllerMock)('whatever', parameters, observer)
         .then(
+          result =>
+            expect(result, 'output value should be false when an error occurs')
+              .to.be.false
+        )
+        .then(
           () =>
             expect(logErrorSpy.calledOnce, 'Should have logged the error').to.be
               .true
@@ -61,6 +73,27 @@ describe('commandConsumer', () => {
             'The error should indicate that the command does not exist'
           ).to.include('Unexisting command')
         )
+        .then(() => done())
+        .catch(e => done(e))
+    })
+  })
+  describe('Given a valid command without an observer', () => {
+    it('Should send a default observer to the controller to be used as command callback', done => {
+      const logMock = createLogMock()
+      const controllerMock = {
+        test: (parameters, observer) =>
+          Promise.resolve().then(() => {
+            expect(
+              typeof observer,
+              'the received observer should be a default function'
+            ).to.equal('function')
+          })
+      }
+
+      commandConsumer(logMock)(controllerMock)('test')
+        .then(result => {
+          expect(result, 'should end with a true value').to.be.true
+        })
         .then(() => done())
         .catch(e => done(e))
     })


### PR DESCRIPTION
This PR:

* Ensure that the callback is always called when an error occurs, with null value and false success
* Ensure the controller always receives observers in the command parameters, setting a default one in the command consumer if none is sent
* Add the possibility to validate the final result as a true/false value from the command promise caller side

![](https://media.giphy.com/media/lcopV5kxO1llu/giphy.gif)