### PR TITLE
Refactor and Log fix

### DIFF
--- a/src/cmp/domain/consent/UpdateConsentVendorsService.js
+++ b/src/cmp/domain/consent/UpdateConsentVendorsService.js
@@ -18,24 +18,19 @@ export default class UpdateConsentVendorsService {
     oldGlobalVendorList,
     allowedVendorIds
   }) {
-    return Promise.resolve()
-      .then(
-        () =>
-          newGlobalVendorList.vendorListVersion !==
-            oldGlobalVendorList.vendorListVersion &&
-          this._resolveNewAcceptedVendorIds({
-            consentAcceptedVendors,
-            newGlobalVendorList,
-            oldGlobalVendorList,
-            allowedVendorIds
-          }).then(newAcceptedVendorIds =>
-            this._saveVendorConsents({
-              purposeConsents: consentAcceptedPurposes,
-              vendorConsents: newAcceptedVendorIds
-            })
-          )
+    return Promise.resolve().then(() =>
+      this._resolveNewAcceptedVendorIds({
+        consentAcceptedVendors,
+        newGlobalVendorList,
+        oldGlobalVendorList,
+        allowedVendorIds
+      }).then(newAcceptedVendorIds =>
+        this._saveVendorConsents({
+          purposeConsents: consentAcceptedPurposes,
+          vendorConsents: newAcceptedVendorIds
+        })
       )
-      .then(null)
+    )
   }
 
   _resolveNewAcceptedVendorIds({

--- a/src/cmp/infrastructure/container/local/DebugLocalConsentContainer.js
+++ b/src/cmp/infrastructure/container/local/DebugLocalConsentContainer.js
@@ -43,8 +43,8 @@ export default class DebugLocalConsentContainer extends LocalConsentContainer {
   }
 
   _buildEagerSingletonInstances() {
-    super._buildEagerSingletonInstances()
     this.getInstance({key: 'Log'})
+    super._buildEagerSingletonInstances()
     const errorObserver = this.getInstance({key: 'ErrorObserverFactory'})
     const debugObserver = this.getInstance({key: 'DebugObserverFactory'})
     DomainEventBus.register({

--- a/src/test/cmp/domain/consent/UpdateConsentVendorsServiceTest.js
+++ b/src/test/cmp/domain/consent/UpdateConsentVendorsServiceTest.js
@@ -6,53 +6,6 @@ import UpdateConsentVendorsService from '../../../../cmp/domain/consent/UpdateCo
 import {NewVendorsStatusService} from '../../../../cmp/domain/vendor_consents/NewVendorsStatusService'
 
 describe('UpdateConsentVendorsService', () => {
-  describe('Given consented vendors with a version list number that is equal to the version list number of the global vendor list', () => {
-    it('Should not change the stored consent', done => {
-      const givenNewGlobalVendorList = GlobalVendorList
-      const givenOldGlobalVendorList = GlobalVendorList
-      const givenAcceptedVendors = givenOldGlobalVendorList.vendors
-        .map(vendor => vendor.id)
-        .slice(0, 5)
-      const givenAcceptedPurposes = givenOldGlobalVendorList.purposes.map(
-        purpose => purpose.id
-      )
-
-      const vendorConsentsRepositoryMock = {
-        saveVendorConsents: () => Promise.resolve()
-      }
-      const saveVendorConsentsSpy = sinon.spy(
-        vendorConsentsRepositoryMock,
-        'saveVendorConsents'
-      )
-
-      const vendorListRepositoryMock = {
-        getGlobalVendorList: () => Promise.resolve()
-      }
-      const newVendorsStatusService = new NewVendorsStatusService()
-
-      const service = new UpdateConsentVendorsService({
-        vendorConsentsRepository: vendorConsentsRepositoryMock,
-        vendorListRepository: vendorListRepositoryMock,
-        newVendorsStatusService
-      })
-
-      service
-        .updateConsentVendorList({
-          consentAcceptedVendors: givenAcceptedVendors,
-          consentAcceptedPurposes: givenAcceptedPurposes,
-          newGlobalVendorList: givenNewGlobalVendorList,
-          oldGlobalVendorList: givenOldGlobalVendorList
-        })
-        .then(() => {
-          expect(
-            saveVendorConsentsSpy.called,
-            'should not call to save any consent when version list number does not change'
-          ).to.be.false
-          done()
-        })
-        .catch(e => done(e))
-    })
-  })
   describe('Given consented vendors with a version list number that differs to the version list number of the global vendor list, assuming that all new vendors are accepted (ALL_ALLOW option)', () => {
     it('Should save a new consent with the new vendors from the v74 list that are not in the v73', done => {
       const givenNewGlobalVendorList = GlobalVendorList


### PR DESCRIPTION
* Log instance must be first loaded
* Remove check different vendor list in service for update consent, is redundant, this service is only used in the observer of Vendor list changed

Keep in mind that we must refactor the domain, so the service UpdateConsentVendorsService will desapear and all this business will be inside a domain entity. Being said that, just for now, the service is only used inside the observer of globalVendorListChanged so checking again if version is changed is not necessary.