### PR TITLE
Fix the vendor list version comparison

### DIFF
--- a/src/cmp/domain/consent/ConsentFactory.js
+++ b/src/cmp/domain/consent/ConsentFactory.js
@@ -51,7 +51,7 @@ export default class ConsentFactory {
     return Promise.resolve().then(() => {
       if (
         newGlobalVendorList.vendorListVersion !==
-        oldGlobalVendorList.oldGlobalVendorList
+        oldGlobalVendorList.vendorListVersion
       ) {
         DomainEventBus.raise({
           domainEvent: globalVendorListVersionChanged({


### PR DESCRIPTION
This PR fixes the vendor list version comparison, avoding the version changed event when the two lists are the same

![](https://media.giphy.com/media/xT9IgNPVbGsa0Wd8li/giphy.gif)