### PR TITLE
Hotfix/get consent data should not throw error

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Background
+
+X
+
+# Goal
+
+X
+
+# Implementation
+
+X
+
+# Further considerations
+
+X
+
+# Checklist
+
+- [ ] The PR relates to *only* one subject with a clear title.
+- [ ] I have performed a self-review of my own code
+- [ ] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
+- [ ] My code is readable by someone else, and I commented the hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+
+# Visual Description
+
+![]()

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,5 @@ coverage
 .travis.yml
 .idea
 .eslintignore
+.github
 resources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/boros-cmp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Schibsted GDPR - Consent Management Provider - Standalone",
   "main": "dist/cmp.pro.js",
   "scripts": {

--- a/src/cmp/application/services/consent/GetConsentDataUseCase.js
+++ b/src/cmp/application/services/consent/GetConsentDataUseCase.js
@@ -1,5 +1,3 @@
-import filterConsentMustExist from '../../../domain/consent/filterConsentMustExist'
-
 export default class GetConsentDataUseCase {
   constructor({
     gdprApplies = true,
@@ -22,11 +20,10 @@ export default class GetConsentDataUseCase {
     // TODO: support consentStringVersion.
     return Promise.resolve()
       .then(this._getStoredConsent)
-      .then(filterConsentMustExist)
       .then(consent => ({
         gdprApplies: this._gdprApplies,
         hasGlobalScope: this._storeConsentGlobally,
-        consentData: consent.getConsentString(false)
+        consentData: (consent && consent.getConsentString(false)) || undefined
       }))
   }
 }

--- a/src/test/cmp/application/GetConsentDataUseCaseTest.js
+++ b/src/test/cmp/application/GetConsentDataUseCaseTest.js
@@ -45,5 +45,37 @@ describe('GetConsentDataUseCase', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+    it('Should return undefined consentData if no consent is set yet', done => {
+      const givenGdprApplies = true
+      const givenHasGlobalScope = false
+      const consentRepositoryMock = {
+        getConsent: () => Promise.resolve(undefined)
+      }
+
+      const getConsentDataUseCase = new GetConsentDataUseCase({
+        consentRepository: consentRepositoryMock,
+        gdprApplies: givenGdprApplies,
+        hasGlobalScope: givenHasGlobalScope
+      })
+
+      getConsentDataUseCase
+        .getConsentData()
+        .then(result => {
+          expect(
+            result.consentData,
+            'Value does not match with the expected.'
+          ).equal(undefined)
+          expect(
+            result.hasGlobalScope,
+            'Value does not match with the expected.'
+          ).equal(givenHasGlobalScope)
+          expect(
+            result.gdprApplies,
+            'Value does not match with the expected.'
+          ).equal(givenGdprApplies)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
 })


### PR DESCRIPTION
# Background

Boros CMP is being tested to be integrated in Fotocasa. An error is printed in the console when an user enters the page, no consent is set yet and some Ads are being loaded using the AppNexus SDK.

# Goal

Remove the error trace as it's not an error.

# Implementation

* Now, when the consent is not set, the getConsentData **will** call the callback with this data:
```
      {
        gdprApplies: ...,
        hasGlobalScope: ..., 
        consentData: undefined //this is the change
      }
```
# Further considerations

The IAB framework is not clear about the implementation, but it says _"The callback is called only after consent is obtained from the UI or existing cookies"_.
Doing that would lead the page to never be able to load Ads if the SDK is not running a race condition (p.ex. a timeout) when it does not receive a response from the callback in a while.

# Checklist

- [X] The PR relates to *only* one subject with a clear title.
- [X] I have performed a self-review of my own code
- [X] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My code is readable by someone else, and I commented the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

# Visual Description

![](https://media.giphy.com/media/Pch8FiF08bc1G/giphy.gif)